### PR TITLE
fix: cni config uninitialized for edge pod

### DIFF
--- a/pkg/operator/controllers/agent/controller.go
+++ b/pkg/operator/controllers/agent/controller.go
@@ -347,6 +347,7 @@ func (ctl *agentController) createAgentPodIfNeeded(ctx context.Context, node *co
 
 func (ctl *agentController) buildAgentPod(namespace, nodeName, podName string) *corev1.Pod {
 	hostPathDirectory := corev1.HostPathDirectory
+	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
 	hostPathFile := corev1.HostPathFile
 	privileged := true
 	defaultMode := int32(420)
@@ -452,7 +453,7 @@ func (ctl *agentController) buildAgentPod(namespace, nodeName, podName string) *
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
 							Path: "/etc/cni",
-							Type: &hostPathDirectory,
+							Type: &hostPathDirectoryOrCreate,
 						},
 					},
 				},

--- a/pkg/operator/controllers/agent/controller_test.go
+++ b/pkg/operator/controllers/agent/controller_test.go
@@ -253,6 +253,7 @@ var _ = Describe("AgentController", func() {
 			Expect(len(pod.Spec.Volumes)).To(Equal(6))
 
 			hostPathDirectory := corev1.HostPathDirectory
+			hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
 			hostPathFile := corev1.HostPathFile
 			defaultMode := int32(420)
 			edgeTunnelConfigMap := getAgentConfigMapName(nodeName)
@@ -268,7 +269,7 @@ var _ = Describe("AgentController", func() {
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
 							Path: "/etc/cni",
-							Type: &hostPathDirectory,
+							Type: &hostPathDirectoryOrCreate,
 						},
 					},
 				},


### PR DESCRIPTION
the edge POD state is always **ContainerCreating**.

edgecore service error log

  ```
  E0804 02:52:50.301237   29915 nestedpendingoperations.go:301] Operation for "{volumeName:kubernetes.io/host-path/d337f65b-86fc-42b6-8d6a-eb37524d81fa-cni podName:d337f65b-86fc-42b6-8d6a-eb37524d81fa nodeName:}" failed. No retries permitted until 2021-08-04 02:52:50.80113798 +0000 UTC m=+149347.048376094 (durationBeforeRetry 500ms). Error: "MountVolume.SetUp failed for volume \"cni\" (UniqueName: \"kubernetes.io/host-path/d337f65b-86fc-42b6-8d6a-eb37524d81fa-cni\") pod \"fabedge-agent-edge\" (UID: \"d337f65b-86fc-42b6-8d6a-eb37524d81fa\") : hostPath type check failed: /etc/cni is not a directory"
... ...

E0805 07:15:15.692826   12800 remote_runtime.go:113] RunPodSandbox from runtime service failed: rpc error: code = Unknown desc = [failed to set up sandbox container "3805fa237d2d7aa4c376c75b504b88a4d59aa2c8d57e5922f68284f2d54448b6" network for pod "edge-pod-nginx": networkPlugin cni failed to set up pod "edge-pod-nginx_fabedge" network: cni config uninitialized, failed to clean up sandbox container "3805fa237d2d7aa4c376c75b504b88a4d59aa2c8d57e5922f68284f2d54448b6" network for pod "edge-pod-nginx": networkPlugin cni failed to teardown pod "edge-pod-nginx_fabedge" network: cni config uninitialized]

  ```