### PR TITLE
fix:failed to remove NAT outgoing iptables rules

### DIFF
--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -271,6 +271,10 @@ func (m *Manager) ensureIPTablesRules(conf netconf.NetworkConf) error {
 
 // outbound NAT from pods to outside of the cluster
 func (m *Manager) configureOutboundRules(subnet string) error {
+	if err := m.ensureChain(TableNat, ChainNatOutgoing); err != nil {
+		return err
+	}
+
 	if m.masqOutgoing {
 		m.log.V(3).Info("configure outgoing NAT iptables rules", "masqOutgoing", m.masqOutgoing)
 		iFace, err := m.netLink.GetDefaultIFace()
@@ -279,10 +283,6 @@ func (m *Manager) configureOutboundRules(subnet string) error {
 		}
 
 		ensureRule := m.ipt.AppendUnique
-		if err := m.ensureChain(TableNat, ChainNatOutgoing); err != nil {
-			return err
-		}
-
 		if err := ensureRule(TableNat, ChainNatOutgoing, "-s", subnet, "-d", m.edgePodCIDR, "-j", "RETURN"); err != nil {
 			return err
 		}
@@ -341,9 +341,6 @@ func (m *Manager) configureOutboundRules(subnet string) error {
 			}
 		}
 
-		if err := m.ipt.DeleteChain(TableNat, ChainNatOutgoing); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Set up `fabedge-agent  -masq-outgoing=false`

fabedge-agent error logs have been found.

```
kubectl logs -f fabedge-agent-edge1 -c agent -n fabedge
```

Error logs: 

```
I0809 01:47:42.671587       1 manager.go:309] manager "msg"="remove NAT outgoing iptables rules if it exists"  "masqOutgoing"=false
E0809 01:47:42.673575       1 manager.go:140] manager "msg"="failed to configure network" "error"="running [/sbin/iptables -t nat -C POSTROUTING -j fabedge-nat-outgoing --wait]: exit status 2: iptables v1.8.3 (legacy): Couldn't load target `fabedge-nat-outgoing':No such file or directory\n\nTry `iptables -h' or 'iptables --help' for more information.\n"  "retryNum"=0
```