### PR TITLE
operator: improve agent pod synchronization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bep/debounce v1.2.0
 	github.com/coreos/go-iptables v0.6.0
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-logr/logr v0.3.0
 	github.com/jjeffery/stringset v1.0.2

--- a/pkg/common/constants/default.go
+++ b/pkg/common/constants/default.go
@@ -18,6 +18,7 @@ const (
 	KeyNodeSubnets = "fabedge.io/subnets"
 	KeyFabedgeAPP  = "fabedge.io/app"
 	KeyCreatedBy   = "fabedge.io/created-by"
+	KeyPodHash     = "fabedge.io/pod-spec-hash"
 	AppAgent       = "fabedge-agent"
 	AppOperator    = "fabedge-operator"
 


### PR DESCRIPTION
In the past, once agent pods were created, they would not be changed
anymore, even arguments or images are changed. Now each agent pod will
have a label "pod-hash", its value is calculated based on pod spec, once
agent controller find that pod-hash is not matched, it will update the pod.