### PR TITLE
proxy: fix the residual services with no endpoints bug

### DIFF
--- a/pkg/operator/controllers/proxy/proxy_test.go
+++ b/pkg/operator/controllers/proxy/proxy_test.go
@@ -676,7 +676,7 @@ var _ = Describe("Proxy", func() {
 
 			By("check edge node2 services and endpoints")
 			node2 := edgeNodeSet["node2"]
-			Expect(len(node2.ServicePortMap)).Should(Equal(2))
+			Expect(len(node2.ServicePortMap)).Should(Equal(0))
 			Expect(len(node2.EndpointMap)).Should(Equal(0))
 
 			Expect(keeper.nodeSet).Should(ContainElement(node2))


### PR DESCRIPTION
Sometimes services with no endpoints are left over, which causes a lot of useless ipvs rules on edge node.