### PR TITLE
Use publicAddresses to replace IP of Tunnel Endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 OUTPUT_DIR := _output
 BINARIES := agent connector operator cert
-IMAGES := $(addsuffix -image, $(BINARIES))
-IMAGES := $(IMAGES) strongswan-image installer-image
+IMAGES := $(addsuffix -image, agent connector operator strongswan installer)
 
 VERSION := v0.1.0
 BUILD_TIME := $(shell date -u '+%Y-%m-%d_%H:%M:%S%z')

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,8 +28,8 @@ spec:
             - -strongswan-image=fabedge/strongswan
             # connector组件所用的configmap名称
             - -connector-config=connector-config
-            # 边缘节点可访问的connector的IP地址
-            - -connector-ip=10.10.10.10
+            # 边缘节点可访问的connector的IP地址或域名，多个地址用逗号分割
+            - -connector-public-addresses=10.10.10.10
             # 请提供非边缘Pod的IP所在的网段以及Service ClusterIP所属的网段
             - -connector-subnets=10.233.64.0/18,10.233.0.0/18
             # 边缘节点生成的证书的ID的格式，{node}会被替换为节点名称

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -229,8 +229,6 @@ func (m *Manager) mainNetwork() error {
 func (m *Manager) ensureConnections(conf netconf.NetworkConf) error {
 	newNames := stringset.New()
 
-	netconf.EnsureNodeSubnets(&conf)
-
 	for _, peer := range conf.Peers {
 		newNames.Add(peer.Name)
 
@@ -243,7 +241,7 @@ func (m *Manager) ensureConnections(conf netconf.NetworkConf) error {
 			LocalCerts:       m.localCerts,
 
 			RemoteID:          peer.ID,
-			RemoteAddress:     []string{peer.IP},
+			RemoteAddress:     peer.PublicAddresses,
 			RemoteSubnets:     peer.Subnets,
 			RemoteNodeSubnets: peer.NodeSubnets,
 		}
@@ -650,9 +648,6 @@ func (m *Manager) getAllPeerCIDRs() (sets.String, error) {
 				cidrSet.Insert(nodeSubnet)
 			}
 		}
-
-		ip := m.ipset.ConvertIPToCIDR(p.IP)
-		cidrSet.Insert(ip)
 
 		cidrSet.Insert(p.Subnets...)
 	}

--- a/pkg/common/netconf/tunnels.go
+++ b/pkg/common/netconf/tunnels.go
@@ -21,9 +21,9 @@ import (
 )
 
 type TunnelEndpoint struct {
-	ID   string `yaml:"id,omitempty"`
-	Name string `yaml:"name,omitempty"`
-	IP   string `yaml:"ip,omitempty"`
+	ID              string   `yaml:"id,omitempty"`
+	Name            string   `yaml:"name,omitempty"`
+	PublicAddresses []string `yaml:"publicAddresses,omitempty"`
 	// only pod subnets are allowed
 	Subnets     []string `yaml:"subnets,omitempty"`
 	NodeSubnets []string `yaml:"nodeSubnets,omitempty"`
@@ -43,19 +43,4 @@ func LoadNetworkConf(path string) (NetworkConf, error) {
 	}
 
 	return conf, yaml.Unmarshal(data, &conf)
-}
-
-func EnsureNodeSubnets(conf *NetworkConf) {
-	if len(conf.NodeSubnets) == 0 {
-		conf.NodeSubnets = append(conf.NodeSubnets, conf.IP)
-	}
-
-	for i, peer := range conf.Peers {
-		if len(peer.NodeSubnets) != 0 {
-			continue
-		}
-
-		peer.NodeSubnets = append(peer.NodeSubnets, peer.IP)
-		conf.Peers[i] = peer
-	}
 }

--- a/pkg/connector/tunnel.go
+++ b/pkg/connector/tunnel.go
@@ -15,7 +15,6 @@
 package connector
 
 import (
-	"fmt"
 	"k8s.io/klog/v2"
 
 	"github.com/fabedge/fabedge/pkg/common/netconf"
@@ -33,24 +32,22 @@ func (m *Manager) readCfgFromFile() error {
 		return err
 	}
 
-	netconf.EnsureNodeSubnets(&nc)
-
 	m.connections = nil
 	connNames = stringset.New()
 
 	for _, peer := range nc.Peers {
 
 		con := tunnel.ConnConfig{
-			Name: fmt.Sprintf("cloud-%s", peer.Name),
+			Name: peer.Name,
 
 			LocalID:          nc.ID,
 			LocalCerts:       []string{m.config.certFile},
-			LocalAddress:     []string{nc.IP},
+			LocalAddress:     nc.PublicAddresses,
 			LocalSubnets:     nc.Subnets,
 			LocalNodeSubnets: nc.NodeSubnets,
 
 			RemoteID:          peer.ID,
-			RemoteAddress:     []string{peer.IP},
+			RemoteAddress:     peer.PublicAddresses,
 			RemoteSubnets:     peer.Subnets,
 			RemoteNodeSubnets: peer.NodeSubnets,
 		}

--- a/pkg/operator/controllers/agent/agentpodhandler.go
+++ b/pkg/operator/controllers/agent/agentpodhandler.go
@@ -27,8 +27,10 @@ cp -f /usr/local/bin/bridge /usr/local/bin/host-local /usr/local/bin/loopback /o
 type agentPodHandler struct {
 	namespace string
 
+	logLevel        int
 	agentImage      string
 	strongswanImage string
+	imagePullPolicy corev1.PullPolicy
 	useXfrm         bool
 	masqOutgoing    bool
 	enableProxy     bool
@@ -132,7 +134,7 @@ func (handler *agentPodHandler) buildAgentPod(namespace, nodeName, podName strin
 				{
 					Name:            "agent",
 					Image:           handler.agentImage,
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					ImagePullPolicy: handler.imagePullPolicy,
 					Args: []string{
 						"-tunnels-conf",
 						agentConfigTunnelsFilepath,
@@ -143,6 +145,7 @@ func (handler *agentPodHandler) buildAgentPod(namespace, nodeName, podName strin
 						fmt.Sprintf("-masq-outgoing=%t", handler.masqOutgoing),
 						fmt.Sprintf("-use-xfrm=%t", handler.useXfrm),
 						fmt.Sprintf("-enable-proxy=%t", handler.enableProxy),
+						fmt.Sprintf("-v=%d", handler.logLevel),
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &privileged,
@@ -176,7 +179,7 @@ func (handler *agentPodHandler) buildAgentPod(namespace, nodeName, podName strin
 				{
 					Name:            "strongswan",
 					Image:           handler.strongswanImage,
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					ImagePullPolicy: handler.imagePullPolicy,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &privileged,
 					},

--- a/pkg/operator/controllers/agent/agentpodhandler_test.go
+++ b/pkg/operator/controllers/agent/agentpodhandler_test.go
@@ -31,6 +31,8 @@ var _ = Describe("AgentPodHandler", func() {
 			namespace:       namespace,
 			agentImage:      agentImage,
 			strongswanImage: strongswanImage,
+			imagePullPolicy: corev1.PullIfNotPresent,
+			logLevel:        3,
 			client:          k8sClient,
 			log:             klogr.New().WithName("agentPodHandler"),
 		}
@@ -171,7 +173,7 @@ var _ = Describe("AgentPodHandler", func() {
 		// install-cni initContainer
 		Expect(pod.Spec.InitContainers[0].Name).To(Equal("install-cni"))
 		Expect(pod.Spec.Containers[0].Image).To(Equal(agentImage))
-		Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+		Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(handler.imagePullPolicy))
 
 		cpCommand := []string{
 			"/bin/sh",
@@ -204,7 +206,7 @@ var _ = Describe("AgentPodHandler", func() {
 		// agent container
 		Expect(pod.Spec.Containers[0].Name).To(Equal("agent"))
 		Expect(pod.Spec.Containers[0].Image).To(Equal(agentImage))
-		Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+		Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(handler.imagePullPolicy))
 		args := []string{
 			"-tunnels-conf",
 			agentConfigTunnelsFilepath,
@@ -215,6 +217,7 @@ var _ = Describe("AgentPodHandler", func() {
 			"-masq-outgoing=false",
 			"-use-xfrm=false",
 			"-enable-proxy=false",
+			"-v=3",
 		}
 		Expect(pod.Spec.Containers[0].Args).To(Equal(args))
 

--- a/pkg/operator/controllers/agent/confighandler_test.go
+++ b/pkg/operator/controllers/agent/confighandler_test.go
@@ -47,10 +47,11 @@ var _ = Describe("ConfigHandler", func() {
 		nodeName := getNodeName()
 		connectorEndpoint = getConnectorEndpoint()
 		edge2Endpoint = types.Endpoint{
-			ID:      "C=CN, O=StrongSwan, CN=edge2",
-			Name:    "edge2",
-			IP:      "10.20.8.141",
-			Subnets: []string{"2.2.1.65/26"},
+			ID:              "C=CN, O=StrongSwan, CN=edge2",
+			Name:            "edge2",
+			PublicAddresses: []string{"10.20.8.141"},
+			Subnets:         []string{"2.2.1.65/26"},
+			NodeSubnets:     []string{"10.20.8.141"},
 		}
 		testCommunity = types.Community{
 			Name:    "test",
@@ -94,8 +95,8 @@ var _ = Describe("ConfigHandler", func() {
 
 	It("Do should update agent configmap when any endpoint changed", func() {
 		By("changing edge2 ip address")
-		edge2IP := "10.20.8.142"
-		edge2Endpoint.IP = edge2IP
+		edge2PublicAddresses := []string{"10.20.8.142"}
+		edge2Endpoint.PublicAddresses = edge2PublicAddresses
 		store.SaveEndpoint(edge2Endpoint)
 
 		By("assign an IP address to node")
@@ -128,7 +129,7 @@ var _ = Describe("ConfigHandler", func() {
 			},
 		}
 		Expect(conf).Should(Equal(expectedConf))
-		Expect(conf.Peers[1].IP).Should(Equal(edge2IP))
+		Expect(conf.Peers[1].PublicAddresses).Should(Equal(edge2PublicAddresses))
 	})
 
 	It("Undo should delete configmap created by Do method", func() {
@@ -142,10 +143,10 @@ var _ = Describe("ConfigHandler", func() {
 
 func getConnectorEndpoint() types.Endpoint {
 	return types.Endpoint{
-		ID:          "C=CN, O=StrongSwan, CN=cloud-connector",
-		Name:        "cloud-connector",
-		IP:          "192.168.1.1",
-		Subnets:     []string{"2.2.1.1/26"},
-		NodeSubnets: []string{"192.168.1.0/24"},
+		ID:              "C=CN, O=StrongSwan, CN=cloud-connector",
+		Name:            "cloud-connector",
+		PublicAddresses: []string{"192.168.1.1"},
+		Subnets:         []string{"2.2.1.1/26"},
+		NodeSubnets:     []string{"192.168.1.0/24"},
 	}
 }

--- a/pkg/operator/controllers/agent/controller.go
+++ b/pkg/operator/controllers/agent/controller.go
@@ -63,6 +63,8 @@ type Config struct {
 	Manager   manager.Manager
 
 	Namespace       string
+	ImagePullPolicy corev1.PullPolicy
+	AgentLogLevel   int
 	AgentImage      string
 	StrongswanImage string
 	UseXfrm         bool
@@ -150,6 +152,8 @@ func initHandlers(cnf Config, cli client.Client, log logr.Logger) []Handler {
 		client:    cli,
 		log:       log.WithName("agentPodHandler"),
 
+		imagePullPolicy: cnf.ImagePullPolicy,
+		logLevel:        cnf.AgentLogLevel,
 		agentImage:      cnf.AgentImage,
 		strongswanImage: cnf.StrongswanImage,
 		useXfrm:         cnf.UseXfrm,

--- a/pkg/operator/controllers/agent/podcidrshandler_test.go
+++ b/pkg/operator/controllers/agent/podcidrshandler_test.go
@@ -99,9 +99,10 @@ var _ = Describe("allocatablePodCIDRsHandler", func() {
 		It("should reallocate a subnet to a edge node if this node's subnet is not match to record in store", func() {
 			nodeName := getNodeName()
 			handler.store.SaveEndpoint(types.Endpoint{
-				Name:    nodeName,
-				IP:      "",
-				Subnets: []string{"2.2.2.2/26"},
+				Name:            nodeName,
+				PublicAddresses: nil,
+				Subnets:         []string{"2.2.2.2/26"},
+				NodeSubnets:     nil,
 			})
 			node := newNode(nodeName, "10.40.20.181", "2.2.2.1/26")
 			Expect(k8sClient.Create(context.Background(), &node)).ShouldNot(HaveOccurred())

--- a/pkg/operator/controllers/community/controller_test.go
+++ b/pkg/operator/controllers/community/controller_test.go
@@ -78,22 +78,22 @@ var _ = Describe("Controller", func() {
 		}()
 
 		store.SaveEndpoint(types.Endpoint{
-			ID:      "1",
-			Name:    "edge1",
-			IP:      "192.168.1.1",
-			Subnets: []string{"2.2.2.1/26"},
+			ID:              "1",
+			Name:            "edge1",
+			PublicAddresses: []string{"192.168.1.1"},
+			Subnets:         []string{"2.2.2.1/26"},
 		})
 		store.SaveEndpoint(types.Endpoint{
-			ID:      "2",
-			Name:    "edge2",
-			IP:      "192.168.1.2",
-			Subnets: []string{"2.2.2.65/26"},
+			ID:              "2",
+			Name:            "edge2",
+			PublicAddresses: []string{"192.168.1.2"},
+			Subnets:         []string{"2.2.2.65/26"},
 		})
 		store.SaveEndpoint(types.Endpoint{
-			ID:      "4",
-			Name:    "edge4",
-			IP:      "192.168.1.4",
-			Subnets: []string{"2.2.2.130/26"},
+			ID:              "4",
+			Name:            "edge4",
+			PublicAddresses: []string{"192.168.1.4"},
+			Subnets:         []string{"2.2.2.130/26"},
 		})
 	})
 

--- a/pkg/operator/controllers/connector/controller.go
+++ b/pkg/operator/controllers/connector/controller.go
@@ -51,14 +51,14 @@ type Node struct {
 }
 
 type Config struct {
-	ConnectorID         string
-	ConnectorName       string
-	ConnectorIP         string
-	ConnectorConfigName string
-	ProvidedSubnets     []string
-	CollectPodCIDRs     bool
-	Namespace           string
-	Interval            time.Duration
+	ConnectorID              string
+	ConnectorName            string
+	ConnectorPublicAddresses []string
+	ConnectorConfigName      string
+	ProvidedSubnets          []string
+	CollectPodCIDRs          bool
+	Namespace                string
+	Interval                 time.Duration
 
 	Store   storepkg.Interface
 	Manager manager.Manager
@@ -70,11 +70,11 @@ type controller struct {
 	configMapKey client.ObjectKey
 	interval     time.Duration
 
-	connectorID     string
-	connectorName   string
-	connectorIP     string
-	providedSubnets []string
-	collectPodCIDRs bool
+	connectorID            string
+	connectorName          string
+	connectorPublicAddress []string
+	providedSubnets        []string
+	collectPodCIDRs        bool
 
 	store  storepkg.Interface
 	client client.Client
@@ -90,13 +90,13 @@ func AddToManager(cnf Config) (types.EndpointGetter, error) {
 	mgr := cnf.Manager
 
 	ctl := &controller{
-		configMapKey:    client.ObjectKey{Name: cnf.ConnectorConfigName, Namespace: cnf.Namespace},
-		interval:        cnf.Interval,
-		connectorID:     cnf.ConnectorID,
-		connectorName:   cnf.ConnectorName,
-		connectorIP:     cnf.ConnectorIP,
-		providedSubnets: cnf.ProvidedSubnets,
-		collectPodCIDRs: cnf.CollectPodCIDRs,
+		configMapKey:           client.ObjectKey{Name: cnf.ConnectorConfigName, Namespace: cnf.Namespace},
+		interval:               cnf.Interval,
+		connectorID:            cnf.ConnectorID,
+		connectorName:          cnf.ConnectorName,
+		connectorPublicAddress: cnf.ConnectorPublicAddresses,
+		providedSubnets:        cnf.ProvidedSubnets,
+		collectPodCIDRs:        cnf.CollectPodCIDRs,
 
 		store:  cnf.Store,
 		log:    mgr.GetLogger().WithName(controllerName),
@@ -315,11 +315,11 @@ func (ctl *controller) rebuildConnectorEndpoint() {
 	}
 
 	ctl.connectorEndpoint = types.Endpoint{
-		ID:          ctl.connectorID,
-		Name:        ctl.connectorName,
-		IP:          ctl.connectorIP,
-		Subnets:     subnets,
-		NodeSubnets: nodeSubnets,
+		ID:              ctl.connectorID,
+		Name:            ctl.connectorName,
+		PublicAddresses: ctl.connectorPublicAddress,
+		Subnets:         subnets,
+		NodeSubnets:     nodeSubnets,
 	}
 }
 

--- a/pkg/operator/controllers/connector/controller_test.go
+++ b/pkg/operator/controllers/connector/controller_test.go
@@ -56,16 +56,18 @@ var _ = Describe("Controller", func() {
 		interval = 2 * time.Second
 
 		edge1Endpoint = types.Endpoint{
-			ID:      "edge1",
-			Name:    "edge1",
-			IP:      "10.20.40.181",
-			Subnets: []string{"2.2.0.1/26"},
+			ID:              "edge1",
+			Name:            "edge1",
+			PublicAddresses: []string{"10.20.40.181"},
+			Subnets:         []string{"2.2.0.1/26"},
+			NodeSubnets:     []string{"10.20.40.181"},
 		}
 		edge2Endpoint = types.Endpoint{
-			ID:      "edge2",
-			Name:    "edge2",
-			IP:      "10.20.40.182",
-			Subnets: []string{"2.2.0.65/26"},
+			ID:              "edge2",
+			Name:            "edge2",
+			PublicAddresses: []string{"10.20.40.182"},
+			Subnets:         []string{"2.2.0.65/26"},
+			NodeSubnets:     []string{"10.20.40.182"},
 		}
 
 		store = storepkg.NewStore()
@@ -93,13 +95,13 @@ var _ = Describe("Controller", func() {
 			Manager: mgr,
 			Store:   store,
 
-			ConnectorIP:         "192.168.1.1",
-			ConnectorID:         "cloud-connector",
-			ConnectorName:       "cloud-connector",
-			ProvidedSubnets:     []string{"10.10.10.1/26"},
-			CollectPodCIDRs:     true,
-			ConnectorConfigName: "connector-config",
-			Namespace:           namespace,
+			ConnectorPublicAddresses: []string{"192.168.1.1"},
+			ConnectorID:              "cloud-connector",
+			ConnectorName:            "cloud-connector",
+			ProvidedSubnets:          []string{"10.10.10.1/26"},
+			CollectPodCIDRs:          true,
+			ConnectorConfigName:      "connector-config",
+			Namespace:                namespace,
 
 			Interval: interval,
 		}
@@ -114,7 +116,7 @@ var _ = Describe("Controller", func() {
 	It("build connector endpoint when node events come", func() {
 		cep := getConnectorEndpoint()
 
-		Expect(cep.IP).Should(Equal(config.ConnectorIP))
+		Expect(cep.PublicAddresses).Should(Equal(config.ConnectorPublicAddresses))
 		Expect(cep.ID).Should(Equal(config.ConnectorID))
 		Expect(cep.Name).Should(Equal(config.ConnectorName))
 		Expect(cep.Subnets).Should(ConsistOf(config.ProvidedSubnets[0], nodeutil.GetPodCIDRs(node1)[0]))
@@ -125,7 +127,7 @@ var _ = Describe("Controller", func() {
 		time.Sleep(time.Second)
 
 		cep = getConnectorEndpoint()
-		Expect(cep.IP).Should(Equal(config.ConnectorIP))
+		Expect(cep.PublicAddresses).Should(Equal(config.ConnectorPublicAddresses))
 		Expect(cep.ID).Should(Equal(config.ConnectorID))
 		Expect(cep.Name).Should(Equal(config.ConnectorName))
 		Expect(cep.Subnets).Should(ConsistOf(config.ProvidedSubnets[0], nodeutil.GetPodCIDRs(node1)[0], nodeutil.GetPodCIDRs(node2)[0]))

--- a/pkg/operator/store/store_test.go
+++ b/pkg/operator/store/store_test.go
@@ -32,17 +32,17 @@ var _ = Describe("Store", func() {
 
 	It("can support endpoint CRUD operations", func() {
 		e1 := types.Endpoint{
-			ID:      "edge1",
-			Name:    "edge1",
-			IP:      "10.40.20.181",
-			Subnets: []string{"2.2.0.0/26"},
+			ID:              "edge1",
+			Name:            "edge1",
+			PublicAddresses: []string{"10.40.20.181"},
+			Subnets:         []string{"2.2.0.0/26"},
 		}
 
 		e2 := types.Endpoint{
-			ID:      "edge2",
-			Name:    "edge2",
-			IP:      "10.40.20.182",
-			Subnets: []string{"2.2.0.64/26"},
+			ID:              "edge2",
+			Name:            "edge2",
+			PublicAddresses: []string{"10.40.20.182"},
+			Subnets:         []string{"2.2.0.64/26"},
 		}
 
 		store.SaveEndpoint(e1)

--- a/pkg/operator/types/endpoint_test.go
+++ b/pkg/operator/types/endpoint_test.go
@@ -29,17 +29,19 @@ import (
 var _ = Describe("Endpoint", func() {
 	It("should equal if all fields are equal", func() {
 		e1 := types.Endpoint{
-			ID:      "test",
-			Name:    "edge2",
-			IP:      "192.168.0.1",
-			Subnets: []string{"2.2.0.0/64"},
+			ID:              "test",
+			Name:            "edge2",
+			PublicAddresses: []string{"192.168.0.1"},
+			Subnets:         []string{"2.2.0.0/64"},
+			NodeSubnets:     []string{"192.168.0.1"},
 		}
 
 		e2 := types.Endpoint{
-			ID:      "test",
-			Name:    "edge2",
-			IP:      "192.168.0.1",
-			Subnets: []string{"2.2.0.0/64"},
+			ID:              "test",
+			Name:            "edge2",
+			PublicAddresses: []string{"192.168.0.1"},
+			Subnets:         []string{"2.2.0.0/64"},
+			NodeSubnets:     []string{"192.168.0.1"},
 		}
 
 		Expect(e1.Equal(e2)).Should(BeTrue())
@@ -50,19 +52,32 @@ var _ = Describe("Endpoint", func() {
 			Expect(ep.IsValid()).Should(BeFalse())
 		},
 
-		Entry("with invalid ip", types.Endpoint{
-			IP:      "2.2.2.257",
-			Subnets: []string{"2.2.0.0/16"},
+		Entry("with invalid subnets", types.Endpoint{
+			PublicAddresses: []string{"2.2.2.255"},
+			Subnets:         []string{"2.2.0.0/33"},
+			NodeSubnets:     []string{"2.2.2.255"},
 		}),
 
-		Entry("with invalid subets", types.Endpoint{
-			IP:      "2.2.2.255",
-			Subnets: []string{"2.2.0.0/33"},
+		Entry("with invalid node subnets", types.Endpoint{
+			PublicAddresses: []string{"2.2.2.2", "www.google.com"},
+			Subnets:         []string{"2.2.0.0/26"},
+			NodeSubnets:     []string{"2.2.0.0/33"},
 		}),
 
-		Entry("with empty ip and subnets", types.Endpoint{
-			IP:      "",
-			Subnets: nil,
+		Entry("with empty ip", types.Endpoint{
+			PublicAddresses: nil,
+			Subnets:         []string{"2.2.0.0/26"},
+			NodeSubnets:     []string{"2.2.2.1/26"},
+		}),
+		Entry("with empty subnets", types.Endpoint{
+			PublicAddresses: []string{"2.2.2.2"},
+			Subnets:         nil,
+			NodeSubnets:     []string{"2.2.2.1/26"},
+		}),
+		Entry("with empty ip", types.Endpoint{
+			PublicAddresses: []string{"2.2.2.2"},
+			Subnets:         []string{"2.2.0.0/26"},
+			NodeSubnets:     nil,
 		}),
 	)
 })
@@ -97,6 +112,6 @@ var _ = Describe("GenerateNewEndpointFunc", func() {
 	})
 
 	It("should extract ip from node.status.address", func() {
-		Expect(endpoint.IP).Should(Equal("192.168.1.1"))
+		Expect(endpoint.PublicAddresses).Should(ConsistOf("192.168.1.1"))
 	})
 })


### PR DESCRIPTION
A tunnel endpoint can have multiple addresses as remote or local
addresses and these addresses can also be DNS names. So it's better
and flexible to use addresses instead of IP only.