### PR TITLE
hotfix:CNI plugin list format needs .conflist suffix to be recognized by k8s

### DIFF
--- a/pkg/agent/env_prepare.sh
+++ b/pkg/agent/env_prepare.sh
@@ -3,7 +3,7 @@
 set -x
 
 # install CNI plugins
-find /etc/cni/net.d/ -type f -not -name fabedge.conf -exec rm {} \;
+find /etc/cni/net.d/ -type f -not -name fabedge.conflist -exec rm {} \;
 cp -f /usr/local/bin/bridge /usr/local/bin/host-local /usr/local/bin/loopback /usr/local/bin/portmap /usr/local/bin/bandwidth /opt/cni/bin
 
 # cleanup flannel stuff

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -309,7 +309,7 @@ func (m *Manager) generateCNIConfig(conf netconf.NetworkConf) error {
 	}
 	cni.Plugins = append(cni.Plugins, bridge, portmap, bandwidth)
 
-	filename := filepath.Join(m.CNI.ConfDir, fmt.Sprintf("%s.conf", m.CNI.NetworkName))
+	filename := filepath.Join(m.CNI.ConfDir, fmt.Sprintf("%s.conflist", m.CNI.NetworkName))
 	data, err := json.MarshalIndent(cni, "", "  ")
 	if err != nil {
 		m.log.Error(err, "failed to marshal cni config")


### PR DESCRIPTION
CNI plugin list format needs .conflist suffix to be recognized by k8s