### PR TITLE
agent: skip errors of add/initiate tunnels

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -142,4 +142,3 @@ func (cfg Config) Manager() (*Manager, error) {
 
 	return m, nil
 }
-

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -154,17 +154,19 @@ func (m *Manager) ensureConnections(conf netconf.NetworkConf) error {
 
 		m.log.V(5).Info("try to add tunnel", "name", peer.Name, "peer", peer)
 		if err := m.tm.LoadConn(conn); err != nil {
-			return err
+			m.log.Error(err, "failed to add tunnel", "tunnel", conn)
+			continue
 		}
 
 		m.log.V(5).Info("try to initiate tunnel", "name", peer.Name)
 		if err := m.tm.InitiateConn(peer.Name); err != nil {
-			return err
+			m.log.Error(err, "failed to initiate tunnel", "tunnel", conn)
 		}
 	}
 
 	oldNames, err := m.tm.ListConnNames()
 	if err != nil {
+		m.log.Error(err, "failed to list connections")
 		return err
 	}
 
@@ -176,7 +178,6 @@ func (m *Manager) ensureConnections(conf netconf.NetworkConf) error {
 
 		if err := m.tm.UnloadConn(name); err != nil {
 			m.log.Error(err, "failed to unload tunnel", "name", name)
-			return err
 		}
 	}
 


### PR DESCRIPTION
If agent could not to initiate a tunnel, then it will try and try again,
other tunnels will not have a chance to be loaded and be activated. Even
worse, other routine tasks will not be executed.