### PR TITLE
operator: provide more flexible way to configure agent pod

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -37,15 +37,9 @@ spec:
             - --edge-labels=node-role.kubernetes.io/edge=
             # 根据所采用的CNI配置, 目前仅支持calico, flannel
             - --cni-type=calico
-            # 如果hairpinmode为true, 可以支持pod由service访问自身
-            - --agent-enable-edge-hairpinmode=true
-            # 边缘节点设置网络插件MTU
-            - --agent-network-plugin-mtu=1400
             # 边缘节点的Pod使用的网段, 当使用Calico时必须配置，该网段不可与connector-subnets里的网段重叠
             - --edge-pod-cidr=10.10.0.0/16
             # 建议在边缘节点不能运行kube-proxy时启用
-            - --agent-enable-proxy=false
-            - --agent-masq-outgoing=true
             - --agent-image=fabedge/agent
             - --agent-strongswan-image=fabedge/strongswan
             # connectorPod的标签，用来查找connector Pod
@@ -57,6 +51,23 @@ spec:
             # 边缘节点生成的证书的ID的格式，{node}会被替换为节点名称
             - --endpoint-id-format=C=CN, O=fabedge.io, CN={node}
             - -v=5
+          # 用环境变量配置agent的参数，每个参数都是'AGENT_ARG_'开头
+          # 需要注意的是，日志级别必须用'AGENT_ARG_LOG_LEVEL'来配置
+          env:
+            - name: AGENT_ARG_LOG_LEVEL
+              value: "3"
+            - name: AGENT_ARG_LOCAL_CERT
+              value: "tls.crt"
+            - name: AGENT_ARG_MASQ_OUTGOING
+              value: "true"
+            - name: AGENT_ARG_ENABLE_IPAM
+              value: "false"
+            - name: AGENT_ARG_ENABLE_HAIRPINMODE
+              value: "true"
+            - name: AGENT_ARG_ENABLE_PROXY
+              value: "false"
+            - name: AGENT_ARG_USE_XFRM
+              value: "false"
           # ports, volumeMounts, readinessProbe配置仅限于cluster-role是host时使用
           ports:
             - containerPort: 3030

--- a/pkg/operator/cmd.go
+++ b/pkg/operator/cmd.go
@@ -47,6 +47,8 @@ func Execute() error {
 
 	about.DisplayAndExitIfRequested()
 
+	opts.ExtractAgentArgumentMap()
+
 	if err := opts.Validate(); err != nil {
 		log.Error(err, "invalid arguments found")
 		return err

--- a/pkg/operator/controllers/agent/agentpodhandler.go
+++ b/pkg/operator/controllers/agent/agentpodhandler.go
@@ -38,16 +38,11 @@ var _ Handler = &agentPodHandler{}
 type agentPodHandler struct {
 	namespace string
 
-	logLevel          int
-	agentImage        string
-	strongswanImage   string
-	imagePullPolicy   corev1.PullPolicy
-	useXfrm           bool
-	masqOutgoing      bool
-	enableProxy       bool
-	enableIPAM        bool
-	enableHairpinMode bool
-	networkPluginMTU  int
+	agentImage      string
+	strongswanImage string
+	imagePullPolicy corev1.PullPolicy
+	args            []string
+	enableIPAM      bool
 
 	client client.Client
 	log    logr.Logger
@@ -132,21 +127,7 @@ func (handler *agentPodHandler) buildAgentPod(namespace, nodeName, podName strin
 					Name:            "agent",
 					Image:           handler.agentImage,
 					ImagePullPolicy: handler.imagePullPolicy,
-					Args: []string{
-						"--tunnels-conf",
-						agentConfigTunnelsFilepath,
-						"--services-conf",
-						agentConfigServicesFilepath,
-						"--local-cert",
-						"tls.crt",
-						fmt.Sprintf("--masq-outgoing=%t", handler.masqOutgoing),
-						fmt.Sprintf("--enable-ipam=%t", handler.enableIPAM),
-						fmt.Sprintf("--enable-hairpinmode=%t", handler.enableHairpinMode),
-						fmt.Sprintf("--network-plugin-mtu=%d", handler.networkPluginMTU),
-						fmt.Sprintf("--use-xfrm=%t", handler.useXfrm),
-						fmt.Sprintf("--enable-proxy=%t", handler.enableProxy),
-						fmt.Sprintf("-v=%d", handler.logLevel),
-					},
+					Args:            handler.args,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &privileged,
 					},

--- a/pkg/operator/controllers/agent/controller.go
+++ b/pkg/operator/controllers/agent/controller.go
@@ -47,6 +47,7 @@ const (
 )
 
 type ObjectKey = client.ObjectKey
+
 type Handler interface {
 	Do(ctx context.Context, node corev1.Node) error
 	Undo(ctx context.Context, nodeName string) error
@@ -66,13 +67,11 @@ type Config struct {
 	Store     storepkg.Interface
 	Manager   manager.Manager
 
-	Namespace       string
-	ImagePullPolicy string
-	AgentLogLevel   int
-	AgentImage      string
-	StrongswanImage string
-	UseXfrm         bool
-	MasqOutgoing    bool
+	Namespace         string
+	AgentImage        string
+	StrongswanImage   string
+	ImagePullPolicy   string
+	AgentPodArguments types.AgentArgumentMap
 
 	GetConnectorEndpoint types.EndpointGetter
 	NewEndpoint          types.NewEndpointFunc
@@ -80,12 +79,6 @@ type Config struct {
 
 	CertManager      certutil.Manager
 	CertOrganization string
-
-	EnableProxy bool
-
-	EnableEdgeIPAM        bool
-	EnableEdgeHairpinMode bool
-	NetworkPluginMTU      int
 }
 
 func AddToManager(cnf Config) error {
@@ -154,16 +147,11 @@ func initHandlers(cnf Config, cli client.Client, log logr.Logger) []Handler {
 		client:    cli,
 		log:       log.WithName("agentPodHandler"),
 
-		imagePullPolicy:   corev1.PullPolicy(cnf.ImagePullPolicy),
-		logLevel:          cnf.AgentLogLevel,
-		agentImage:        cnf.AgentImage,
-		strongswanImage:   cnf.StrongswanImage,
-		useXfrm:           cnf.UseXfrm,
-		masqOutgoing:      cnf.MasqOutgoing,
-		enableProxy:       cnf.EnableProxy,
-		enableIPAM:        true,
-		enableHairpinMode: cnf.EnableEdgeHairpinMode,
-		networkPluginMTU:  cnf.NetworkPluginMTU,
+		imagePullPolicy: corev1.PullPolicy(cnf.ImagePullPolicy),
+		agentImage:      cnf.AgentImage,
+		strongswanImage: cnf.StrongswanImage,
+		enableIPAM:      cnf.AgentPodArguments.IsIPAMEnabled(),
+		args:            cnf.AgentPodArguments.ArgumentArray(),
 	})
 
 	return handlers

--- a/pkg/operator/types/agent_argument_map.go
+++ b/pkg/operator/types/agent_argument_map.go
@@ -1,0 +1,105 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// AgentArgumentMap is used to manage arguments of agent pod
+type AgentArgumentMap map[string]string
+
+func NewAgentArgumentMap() AgentArgumentMap {
+	return make(AgentArgumentMap)
+}
+
+// NewAgentArgumentMapFromEnv extract arguments of agent pod
+// from ENV, each agent argument should be configured like:
+//
+// 			AGENT_ARG_ENABLE_IPAM=true
+//
+// The return value is a map, each key is the ENV variable name but with
+// prefix 'AGENT_ARG_' stripped and the key is also lowered.
+func NewAgentArgumentMapFromEnv() AgentArgumentMap {
+	const prefix = "agent-arg-"
+
+	argMap := make(AgentArgumentMap)
+	for _, line := range os.Environ() {
+		parts := strings.SplitN(line, "=", 2)
+
+		// lower variable name and replace '_' with '-'
+		name := strings.ToLower(parts[0])
+		name = strings.ReplaceAll(name, "_", "-")
+
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+
+		name = name[len(prefix):]
+		value := ""
+		if len(parts) > 1 {
+			value = parts[1]
+		}
+
+		argMap[name] = value
+	}
+
+	return argMap
+}
+
+func (argMap AgentArgumentMap) Set(name, value string) {
+	argMap[name] = value
+}
+
+func (argMap AgentArgumentMap) Get(name string) string {
+	return argMap[name]
+}
+
+func (argMap AgentArgumentMap) Delete(name string) {
+	delete(argMap, name)
+}
+
+func (argMap AgentArgumentMap) HasKey(name string) bool {
+	_, ok := argMap[name]
+	return ok
+}
+
+func (argMap AgentArgumentMap) IsIPAMEnabled() bool {
+	return argMap.isTrue("enable-ipam")
+}
+
+func (argMap AgentArgumentMap) IsProxyEnabled() bool {
+	return argMap.isTrue("enable-proxy")
+}
+
+func (argMap AgentArgumentMap) isTrue(name string) bool {
+	return argMap[name] == "true"
+}
+
+// ArgumentArray translate argument map into sorted argument array
+// All arguments are sorted except log level, `agent` doesn't have
+// an option named log-level, instead it has a 'v' option which is used
+// to configure log level. ArgumentArray will put 'v' option at the end of argument array.
+func (argMap AgentArgumentMap) ArgumentArray() []string {
+	const nameLogLevel = "log-level"
+
+	nameSet := sets.NewString()
+	for name := range argMap {
+		nameSet.Insert(name)
+	}
+
+	args := make([]string, 0, len(argMap)+1)
+	for _, name := range nameSet.List() {
+		if name != nameLogLevel {
+			args = append(args, fmt.Sprintf("--%s=%s", name, argMap[name]))
+		}
+	}
+
+	if value, ok := argMap[nameLogLevel]; ok {
+		args = append(args, fmt.Sprintf("--v=%s", value))
+	}
+
+	return args
+}

--- a/pkg/operator/types/agent_argument_map_test.go
+++ b/pkg/operator/types/agent_argument_map_test.go
@@ -1,0 +1,119 @@
+package types_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/fabedge/fabedge/pkg/operator/types"
+)
+
+var _ = Describe("AgentArgumentMap", func() {
+	It("can set, get and delete key and value pairs", func() {
+		argMap := types.NewAgentArgumentMap()
+
+		Expect(argMap.HasKey("hello")).To(BeFalse())
+		Expect(argMap.Get("hello")).To(Equal(""))
+
+		argMap.Set("hello", "world")
+
+		Expect(argMap.HasKey("hello")).To(BeTrue())
+		Expect(argMap.Get("hello")).To(Equal("world"))
+
+		argMap.Delete("hello")
+		Expect(argMap.HasKey("hello")).To(BeFalse())
+		Expect(argMap.Get("hello")).To(Equal(""))
+	})
+
+	It("IsIPAMEnabled return true only if key 'enable-ipam' exists and has value 'true'", func() {
+		argMap := types.NewAgentArgumentMap()
+
+		key := "enable-ipam"
+		argMap.Set(key, "")
+		Expect(argMap.IsProxyEnabled()).To(BeFalse())
+
+		argMap.Set(key, "true")
+		Expect(argMap.IsIPAMEnabled()).To(BeTrue())
+	})
+
+	It("IsProxyEnabled return true only if 'enable-proxy' exists and has value 'true'", func() {
+		argMap := types.NewAgentArgumentMap()
+
+		key := "enable-proxy"
+		argMap.Set(key, "")
+		Expect(argMap.IsProxyEnabled()).To(BeFalse())
+
+		argMap.Set(key, "true")
+		Expect(argMap.IsProxyEnabled()).To(BeTrue())
+	})
+
+	It("ArgumentArray will generate an argument array sorted by argument name", func() {
+		argMap := types.NewAgentArgumentMap()
+
+		argMap.Set("enable-proxy", "false")
+		argMap.Set("enable-ipam", "true")
+
+		argumentArray := argMap.ArgumentArray()
+		Expect(argumentArray).To(Equal([]string{
+			"--enable-ipam=true",
+			"--enable-proxy=false",
+		}))
+	})
+
+	It("ArgumentArray always put log-level at the end of array and use 'v' replace it", func() {
+		argMap := types.NewAgentArgumentMap()
+
+		argMap.Set("log-level", "3")
+		argMap.Set("enable-ipam", "true")
+
+		argumentArray := argMap.ArgumentArray()
+		Expect(argumentArray).To(Equal([]string{
+			"--enable-ipam=true",
+			"--v=3",
+		}))
+	})
+
+	It("ArgumentArray will generate an argument array sorted by argument name", func() {
+		argMap := types.NewAgentArgumentMap()
+
+		argMap.Set("log-level", "3")
+		argMap.Set("enable-ipam", "true")
+		argMap.Set("enable-proxy", "false")
+
+		argumentArray := argMap.ArgumentArray()
+		Expect(argumentArray).To(Equal([]string{
+			"--enable-ipam=true",
+			"--enable-proxy=false",
+			"--v=3",
+		}))
+	})
+})
+
+var _ = Describe("NewAgentArgumentMapFromEnv", func() {
+	BeforeEach(func() {
+		os.Setenv("AGENT_ARG_LOG_LEVEL", "3")
+		os.Setenv("AGENT_ARG_ENABLE_IPAM", "true")
+		os.Setenv("AGENT_ARG_ENABLE_PROXY", "")
+	})
+
+	AfterEach(func() {
+		os.Unsetenv("AGENT_ARG_LOG_LEVEL")
+		os.Unsetenv("AGENT_ARG_ENABLE_IPAM")
+		os.Unsetenv("AGENT_ARG_ENABLE_PROXY")
+	})
+
+	It("build an AgentArgumentMap from environment variables which have prefix 'AGENT_ARG_'", func() {
+		argMap := types.NewAgentArgumentMapFromEnv()
+
+		Expect(len(argMap)).To(Equal(3))
+	})
+
+	It("each environment variable will be saved but its key will has prefix 'AGENT_ARG_' removed and lowered and all '_' are replaces with '-' ", func() {
+		argMap := types.NewAgentArgumentMapFromEnv()
+
+		Expect(argMap.Get("log-level")).To(Equal("3"))
+		Expect(argMap.IsIPAMEnabled()).To(BeTrue())
+		Expect(argMap.IsProxyEnabled()).To(BeFalse())
+	})
+})

--- a/pkg/operator/types/funcs_test.go
+++ b/pkg/operator/types/funcs_test.go
@@ -92,5 +92,4 @@ var _ = Describe("EndpointFuncs", func() {
 
 		Expect(endpoint.PublicAddresses).Should(ConsistOf("www.example.com", "10.0.0.1"))
 	})
-
 })


### PR DESCRIPTION
Previously, we use fixed options to configure agent pod arguments.
If agent has new option then we have to add new option to operator.
This is not flexible and extensible, so we changed the way to
configure agent arguments by using enviroment variables.

Signed-off-by: yanjianbo <yanjianbo@beyondcent.com>