### PR TITLE
Remove enable-ipam option from agent

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -60,8 +60,6 @@ spec:
               value: "tls.crt"
             - name: AGENT_ARG_MASQ_OUTGOING
               value: "true"
-            - name: AGENT_ARG_ENABLE_IPAM
-              value: "false"
             - name: AGENT_ARG_ENABLE_HAIRPINMODE
               value: "true"
             - name: AGENT_ARG_ENABLE_PROXY

--- a/pkg/agent/cmd.go
+++ b/pkg/agent/cmd.go
@@ -52,11 +52,9 @@ func Execute() error {
 		return err
 	}
 
-	if manager.EnableIPAM {
-		if err := os.MkdirAll(cfg.CNI.ConfDir, 0777); err != nil {
-			log.Error(err, "failed to create cni conf dir")
-			return err
-		}
+	if err := os.MkdirAll(cfg.CNI.ConfDir, 0777); err != nil {
+		log.Error(err, "failed to create cni conf dir")
+		return err
 	}
 
 	go manager.start()

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -50,7 +50,6 @@ type Config struct {
 	XFRMInterfaceName string
 	XFRMInterfaceID   uint
 
-	EnableIPAM        bool
 	EnableHairpinMode bool
 	NetworkPluginMTU  int
 	CNI               CNI
@@ -66,7 +65,6 @@ func (cfg *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&cfg.DebounceDuration, "debounce", time.Second, "The debounce delay to avoid too much network reconfiguring")
 	fs.DurationVar(&cfg.SyncPeriod, "sync-period", 30*time.Second, "The period to synchronize network configuration")
 
-	fs.BoolVar(&cfg.EnableIPAM, "enable-ipam", true, "enable the IPAM feature")
 	fs.BoolVar(&cfg.EnableHairpinMode, "enable-hairpinmode", true, "enable the Hairpin feature")
 	fs.IntVar(&cfg.NetworkPluginMTU, "network-plugin-mtu", 1400, "Set network plugin MTU for edge nodes")
 	fs.StringVar(&cfg.CNI.Version, "cni-version", "0.3.1", "cni version")
@@ -103,8 +101,6 @@ func (cfg Config) Manager() (*Manager, error) {
 			return nil, err
 		}
 	}
-
-	cfg.MASQOutgoing = cfg.EnableIPAM && cfg.MASQOutgoing
 
 	var opts strongswan.Options
 	if cfg.UseXFRM {

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -113,11 +113,9 @@ func (m *Manager) mainNetwork() error {
 		return err
 	}
 
-	if m.EnableIPAM {
-		m.log.V(3).Info("generate cni config file")
-		if err := m.generateCNIConfig(conf); err != nil {
-			return err
-		}
+	m.log.V(3).Info("generate cni config file")
+	if err := m.generateCNIConfig(conf); err != nil {
+		return err
 	}
 
 	m.log.V(3).Info("keep iptables rules")

--- a/pkg/operator/controllers/agent/controller.go
+++ b/pkg/operator/controllers/agent/controller.go
@@ -150,7 +150,6 @@ func initHandlers(cnf Config, cli client.Client, log logr.Logger) []Handler {
 		imagePullPolicy: corev1.PullPolicy(cnf.ImagePullPolicy),
 		agentImage:      cnf.AgentImage,
 		strongswanImage: cnf.StrongswanImage,
-		enableIPAM:      cnf.AgentPodArguments.IsIPAMEnabled(),
 		args:            cnf.AgentPodArguments.ArgumentArray(),
 	})
 

--- a/pkg/operator/options.go
+++ b/pkg/operator/options.go
@@ -330,7 +330,7 @@ func (opts Options) Validate() (err error) {
 		}
 	}
 
-	if opts.Agent.AgentPodArguments.IsIPAMEnabled() {
+	if opts.CNIType == constants.CNIFlannel {
 		ip, subnet, err := net.ParseCIDR(opts.EdgePodCIDR)
 		if err != nil {
 			return fmt.Errorf("invalid edge pod cidr: %s. %w", opts.EdgePodCIDR, err)
@@ -571,7 +571,7 @@ func (opts Options) recordEndpoints(ctx context.Context) error {
 		})
 	}
 
-	if !opts.Agent.AgentPodArguments.IsIPAMEnabled() {
+	if opts.CNIType == constants.CNIFlannel {
 		return nil
 	}
 

--- a/pkg/operator/types/agent_argument_map.go
+++ b/pkg/operator/types/agent_argument_map.go
@@ -66,10 +66,6 @@ func (argMap AgentArgumentMap) HasKey(name string) bool {
 	return ok
 }
 
-func (argMap AgentArgumentMap) IsIPAMEnabled() bool {
-	return argMap.isTrue("enable-ipam")
-}
-
 func (argMap AgentArgumentMap) IsProxyEnabled() bool {
 	return argMap.isTrue("enable-proxy")
 }

--- a/pkg/operator/types/agent_argument_map_test.go
+++ b/pkg/operator/types/agent_argument_map_test.go
@@ -26,17 +26,6 @@ var _ = Describe("AgentArgumentMap", func() {
 		Expect(argMap.Get("hello")).To(Equal(""))
 	})
 
-	It("IsIPAMEnabled return true only if key 'enable-ipam' exists and has value 'true'", func() {
-		argMap := types.NewAgentArgumentMap()
-
-		key := "enable-ipam"
-		argMap.Set(key, "")
-		Expect(argMap.IsProxyEnabled()).To(BeFalse())
-
-		argMap.Set(key, "true")
-		Expect(argMap.IsIPAMEnabled()).To(BeTrue())
-	})
-
 	It("IsProxyEnabled return true only if 'enable-proxy' exists and has value 'true'", func() {
 		argMap := types.NewAgentArgumentMap()
 
@@ -93,27 +82,23 @@ var _ = Describe("AgentArgumentMap", func() {
 var _ = Describe("NewAgentArgumentMapFromEnv", func() {
 	BeforeEach(func() {
 		os.Setenv("AGENT_ARG_LOG_LEVEL", "3")
-		os.Setenv("AGENT_ARG_ENABLE_IPAM", "true")
 		os.Setenv("AGENT_ARG_ENABLE_PROXY", "")
 	})
 
 	AfterEach(func() {
 		os.Unsetenv("AGENT_ARG_LOG_LEVEL")
-		os.Unsetenv("AGENT_ARG_ENABLE_IPAM")
 		os.Unsetenv("AGENT_ARG_ENABLE_PROXY")
 	})
 
 	It("build an AgentArgumentMap from environment variables which have prefix 'AGENT_ARG_'", func() {
 		argMap := types.NewAgentArgumentMapFromEnv()
-
-		Expect(len(argMap)).To(Equal(3))
+		Expect(len(argMap)).To(Equal(2))
 	})
 
 	It("each environment variable will be saved but its key will has prefix 'AGENT_ARG_' removed and lowered and all '_' are replaces with '-' ", func() {
 		argMap := types.NewAgentArgumentMapFromEnv()
 
 		Expect(argMap.Get("log-level")).To(Equal("3"))
-		Expect(argMap.IsIPAMEnabled()).To(BeTrue())
 		Expect(argMap.IsProxyEnabled()).To(BeFalse())
 	})
 })


### PR DESCRIPTION
For a long time, we had been mistaking allocating PodCIDR
and IPAM. But they are different. We always need IPAM on edge node, but
only need PodCIDR allocation when CNI is calico.

Signed-off-by: yanjianbo <yanjianbo@beyondcent.com>