### PR TITLE
operator: change the naming strategy of fabedge-agent pod

### DIFF
--- a/pkg/common/constants/default.go
+++ b/pkg/common/constants/default.go
@@ -16,7 +16,8 @@ package constants
 
 const (
 	KeyPodSubnets          = "fabedge.io/subnets"
-	KeyFabedgeAPP          = "fabedge.io/app"
+	KeyFabEdgeAPP          = "fabedge.io/app"
+	KeyFabEdgeName         = "fabedge.io/name"
 	KeyCreatedBy           = "fabedge.io/created-by"
 	KeyNode                = "fabedge.io/node"
 	KeyNodePublicAddresses = "fabedge.io/node-public-addresses"

--- a/pkg/operator/controllers/agent/confighandler.go
+++ b/pkg/operator/controllers/agent/confighandler.go
@@ -76,7 +76,7 @@ func (handler *configHandler) Do(ctx context.Context, node corev1.Node) error {
 				Name:      configName,
 				Namespace: handler.namespace,
 				Labels: map[string]string{
-					constants.KeyFabedgeAPP: constants.AppAgent,
+					constants.KeyFabEdgeAPP: constants.AppAgent,
 					constants.KeyCreatedBy:  constants.AppOperator,
 				},
 			},

--- a/pkg/operator/controllers/proxy/load_balance_config_keeper_test.go
+++ b/pkg/operator/controllers/proxy/load_balance_config_keeper_test.go
@@ -80,7 +80,7 @@ var _ = Describe("loadBalanceConfigKeeper", func() {
 				Name:      configName,
 				Namespace: namespace,
 				Labels: map[string]string{
-					constants.KeyFabedgeAPP: constants.AppAgent,
+					constants.KeyFabEdgeAPP: constants.AppAgent,
 					constants.KeyCreatedBy:  constants.AppOperator,
 				},
 			},


### PR DESCRIPTION
fabedge-agent pods tends to stuck on Pending phase on KubeEdge as
it has some problem with resources using the same name.

Signed-off-by: yanjianbo <yanjianbo@beyondcent.com>