### PR TITLE
Fix IPv6 CIDR equality check failure problem

### DIFF
--- a/pkg/tunnel/strongswan/strongswan.go
+++ b/pkg/tunnel/strongswan/strongswan.go
@@ -437,7 +437,7 @@ func normalizeCIDR(value string) string {
 
 	maskLen := 32
 	if strings.IndexByte(value, ':') > -1 {
-		maskLen = 64
+		maskLen = 128
 	}
 
 	return fmt.Sprintf("%s/%d", value, maskLen)


### PR DESCRIPTION
Sometimes user might provide IPv6 CIDRs in a format which might be not abbreviated enough, e.g. fd96:ee88:0:1::0/116. This can cause CIDR equality check failure because fabedge uses string comparison. By normalize CIDR parameters can avoid this problem.

Signed-off-by: yanjianbo <yanjianbo@beyondcent.com>