### PR TITLE
Implement hold-punching

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -74,6 +74,8 @@ type Config struct {
 	EndpointTTL          time.Duration
 	BackupInterval       time.Duration
 	Workdir              string
+
+	TunnelInitTimeout uint
 }
 
 func (cfg *Config) AddFlags(fs *pflag.FlagSet) {
@@ -110,6 +112,8 @@ func (cfg *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&cfg.MulticastInterval, "multicast-interval", 5*time.Second, "The interval between endpoint multicasting")
 	fs.DurationVar(&cfg.BackupInterval, "backup-interval", 10*time.Second, "The interval between local endpoints backing up")
 	fs.DurationVar(&cfg.EndpointTTL, "endpoint-ttl", 20*time.Second, "The time to live for endpoint received from multicasting")
+
+	fs.UintVar(&cfg.TunnelInitTimeout, "tunnel-init-timeout", 10, "The timeout of tunnel initiation. Uint: second")
 }
 
 func (cfg *Config) Validate() error {
@@ -163,6 +167,7 @@ func (cfg Config) Manager() (*Manager, error) {
 	tm, err := strongswan.New(
 		strongswan.StartAction("clear"),
 		strongswan.DpdDelay("10s"),
+		strongswan.InitTimeout(cfg.TunnelInitTimeout),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/endpoint.go
+++ b/pkg/agent/endpoint.go
@@ -39,6 +39,12 @@ func (m *Manager) loadNetworkConf() error {
 		Endpoint: conf.Endpoint,
 	}
 
+	if conf.Mediator != nil {
+		m.mediatorEndpoint = &Endpoint{
+			Endpoint: *conf.Mediator,
+		}
+	}
+
 	nameSet := sets.NewString()
 	for _, peer := range conf.Peers {
 		// local endpoints has higher priority than tunnel endpoint
@@ -149,6 +155,13 @@ func (m *Manager) getCurrentEndpoint() Endpoint {
 	defer m.endpointLock.RUnlock()
 
 	return m.currentEndpoint
+}
+
+func (m *Manager) getMediatorEndpoint() *Endpoint {
+	m.endpointLock.RLock()
+	defer m.endpointLock.RUnlock()
+
+	return m.mediatorEndpoint
 }
 
 func (m *Manager) getPeerEndpoints() []Endpoint {

--- a/pkg/common/constants/default.go
+++ b/pkg/common/constants/default.go
@@ -38,4 +38,6 @@ const (
 
 const (
 	TableStrongswan = 220
+
+	DefaultMediatorName = "mediator"
 )

--- a/pkg/common/netconf/tunnels.go
+++ b/pkg/common/netconf/tunnels.go
@@ -25,6 +25,7 @@ import (
 type NetworkConf struct {
 	apis.Endpoint `yaml:"-,inline"`
 	Peers         []apis.Endpoint `yaml:"peers,omitempty" json:"peers,omitempty"`
+	Mediator      *apis.Endpoint  `yaml:"mediator,omitempty" json:"mediator,omitempty"`
 }
 
 func LoadNetworkConf(path string) (NetworkConf, error) {

--- a/pkg/connector/manager.go
+++ b/pkg/connector/manager.go
@@ -49,13 +49,14 @@ type Manager struct {
 }
 
 type Config struct {
-	SyncPeriod       time.Duration //sync interval
-	DebounceDuration time.Duration
-	TunnelConfigFile string
-	CertFile         string
-	ViciSocket       string
-	CNIType          string
-	initMembers      []string
+	SyncPeriod        time.Duration //sync interval
+	DebounceDuration  time.Duration
+	TunnelConfigFile  string
+	CertFile          string
+	ViciSocket        string
+	CNIType           string
+	InitMembers       []string
+	TunnelInitTimeout uint
 }
 
 func msgHandler(b []byte)         {}
@@ -68,7 +69,8 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CNIType, "cni-type", "flannel", "CNI type used in cloud")
 	fs.DurationVar(&c.SyncPeriod, "sync-period", 5*time.Minute, "period to sync routes/rules")
 	fs.DurationVar(&c.DebounceDuration, "debounce-duration", 5*time.Second, "period to sync routes/rules")
-	fs.StringSliceVar(&c.initMembers, "connector-node-addresses", []string{}, "internal address of all connector nodes")
+	fs.StringSliceVar(&c.InitMembers, "connector-node-addresses", []string{}, "internal address of all connector nodes")
+	fs.UintVar(&c.TunnelInitTimeout, "tunnel-init-timeout", 10, "The timeout of tunnel initiation. Unit: second")
 }
 
 func (c Config) Manager() (*Manager, error) {
@@ -85,7 +87,7 @@ func (c Config) Manager() (*Manager, error) {
 		return nil, err
 	}
 
-	mc, err := memberlist.New(c.initMembers, msgHandler, nodeLeveHandler)
+	mc, err := memberlist.New(c.InitMembers, msgHandler, nodeLeveHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controllers/agent/confighandler.go
+++ b/pkg/operator/controllers/agent/confighandler.go
@@ -130,6 +130,11 @@ func (handler *configHandler) buildNetworkConf(nodeName string) netconf.NetworkC
 		conf.Peers = append(conf.Peers, ep)
 	}
 
+	mediator, found := store.GetEndpoint(constants.DefaultMediatorName)
+	if found {
+		conf.Mediator = &mediator
+	}
+
 	return conf
 }
 

--- a/pkg/operator/controllers/connector/controller.go
+++ b/pkg/operator/controllers/connector/controller.go
@@ -163,6 +163,10 @@ func (ctl *controller) updateConfigMapIfNeeded() {
 		Endpoint: connectorEndpoint,
 		Peers:    ctl.getPeers(),
 	}
+	mediator, found := ctl.Store.GetEndpoint(constants.DefaultMediatorName)
+	if found {
+		conf.Mediator = &mediator
+	}
 
 	confBytes, err := yaml.Marshal(conf)
 	if err != nil {

--- a/pkg/operator/controllers/connector/controller_test.go
+++ b/pkg/operator/controllers/connector/controller_test.go
@@ -231,6 +231,21 @@ var _ = Describe("Controller", func() {
 		conf = getNetworkConf()
 		Expect(conf.Endpoint).To(Equal(getConnectorEndpoint()))
 		Expect(conf.Peers).To(ConsistOf(alienConnector, localEdge1))
+
+		By("Add mediator endpoint")
+		store.SaveEndpoint(apis.Endpoint{
+			Name:            constants.DefaultMediatorName,
+			ID:              config.Endpoint.ID,
+			PublicAddresses: config.Endpoint.PublicAddresses,
+		})
+
+		time.Sleep(2 * interval)
+
+		cm = corev1.ConfigMap{}
+		Expect(k8sClient.Get(context.Background(), key, &cm)).ShouldNot(HaveOccurred())
+
+		conf = getNetworkConf()
+		Expect(conf.Mediator).NotTo(BeNil())
 	})
 
 	It("should create a tls secret for connector", func() {

--- a/pkg/operator/options.go
+++ b/pkg/operator/options.go
@@ -90,6 +90,7 @@ type Options struct {
 	Agent               agentctl.Config
 	Connector           connectorctl.Config
 	ConnectorPublicPort uint
+	ConnectorAsMediator bool
 
 	ManagerOpts manager.Options
 
@@ -127,6 +128,7 @@ func (opts *Options) AddFlags(flag *pflag.FlagSet) {
 	flag.StringToStringVar(&opts.Connector.ConnectorLabels, "connector-labels", map[string]string{"app": "fabedge-connector"}, "The labels used to find connector pods, e.g. key2=,key3=value3")
 	flag.StringSliceVar(&opts.Connector.Endpoint.PublicAddresses, "connector-public-addresses", nil, "The connector's public addresses which should be accessible for every edge node, comma separated. Takes single IPv4 addresses, DNS names")
 	flag.UintVar(&opts.ConnectorPublicPort, "connector-public-port", 500, "Public UDP port for IKE communication of connector")
+	flag.BoolVar(&opts.ConnectorAsMediator, "connector-as-mediator", false, "Use connector as mediator for hole punching")
 	flag.StringSliceVar(&opts.Connector.ProvidedSubnets, "connector-subnets", nil, "The subnets of connector, mostly the CIDRs to assign pod IP and service ClusterIP")
 	flag.DurationVar(&opts.Connector.SyncInterval, "connector-config-sync-interval", 5*time.Second, "The interval to synchronize connector configmap")
 
@@ -263,6 +265,18 @@ func (opts *Options) Complete() (err error) {
 	opts.Connector.Endpoint.ID = getEndpointID("connector")
 	if opts.ConnectorPublicPort != 500 {
 		opts.Connector.Endpoint.Port = &opts.ConnectorPublicPort
+	}
+	if opts.ConnectorAsMediator {
+		mediator := opts.Connector.Endpoint
+		mediator.Name = constants.DefaultMediatorName
+
+		if opts.ConnectorPublicPort != 500 {
+			mediator.Port = opts.Connector.Endpoint.Port
+		}
+
+		mediator.Subnets = nil
+		mediator.NodeSubnets = nil
+		opts.Store.SaveEndpoint(mediator)
 	}
 
 	if opts.ClusterRole == RoleHost {

--- a/pkg/tunnel/manager.go
+++ b/pkg/tunnel/manager.go
@@ -42,4 +42,14 @@ type ConnConfig struct {
 	RemoteNodeSubnets []string
 	RemoteType        apis.EndpointType
 	RemotePort        *uint
+
+	// Whether this connection is used for mediation
+	Mediation bool
+
+	// whether is connection need mediation
+	NeedMediation bool
+	// check https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html
+	// for detailed explanation for MediatedBy and MediationPeer
+	MediatedBy    string
+	MediationPeer string
 }

--- a/pkg/tunnel/strongswan/options.go
+++ b/pkg/tunnel/strongswan/options.go
@@ -52,3 +52,11 @@ func InterfaceID(id *uint) option {
 		m.interfaceID = id
 	}
 }
+
+// InitTimeout set timeout for SA/child-SA initiation. 0 means blocking initiation
+// unit: second.
+func InitTimeout(timeout uint) option {
+	return func(m *StrongSwanManager) {
+		m.initTimeout = timeout * 1000
+	}
+}


### PR DESCRIPTION
In most cases, edge nodes are located in NAT networks which could be a problem for edge ndoes to establish VPN tunnels. IPSec's mediation feature provide a solution to this situation.