### PR TITLE
Change default proxy mode to iptables

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -102,7 +102,7 @@ func (cfg *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.DNS.ClusterDomain, "dns-cluster-domain", "cluster.local", "The kubernetes cluster's domain name")
 
 	fs.BoolVar(&cfg.Proxy.Enabled, "enable-proxy", false, "Enable the proxy feature")
-	fs.StringVar(&cfg.Proxy.Mode, "proxy-mode", "ipvs", "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs'.")
+	fs.StringVar(&cfg.Proxy.Mode, "proxy-mode", "iptables", "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs'.")
 	fs.StringVar(&cfg.Proxy.ClusterCIDR, "proxy-cluster-cidr", "", "The CIDR range of pods in the cluster.")
 
 	fs.BoolVar(&cfg.EnableAutoNetworking, "auto-networking", false, "Enable auto-networking which will find endpoints in the same LAN")


### PR DESCRIPTION
It's not possible for a client use hostNetwork to visit a service whose endpoints also uses hostNetwork when proxy mode is ipvs, using iptables mode can fix it https://github.com/strongswan/strongswan/discussions/1605.