### PR TITLE
Add custom coredns kubernetes plugin

### DIFF
--- a/coredns/plugin/kubernetes/README.md
+++ b/coredns/plugin/kubernetes/README.md
@@ -1,0 +1,241 @@
+# kubernetes
+
+## Name
+
+*kubernetes* - enables reading zone data from a Kubernetes cluster.
+
+## Description
+
+This plugin implements the [Kubernetes DNS-Based Service Discovery
+Specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md).
+
+CoreDNS running the kubernetes plugin can be used as a replacement for kube-dns in a kubernetes
+cluster.  See the [deployment](https://github.com/coredns/deployment) repository for details on [how
+to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
+
+[stubDomains and upstreamNameservers](https://kubernetes.io/blog/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes/)
+are implemented via the *forward* plugin. See the examples below.
+
+This plugin can only be used once per Server Block.
+
+## Syntax
+
+~~~
+kubernetes [ZONES...]
+~~~
+
+With only the plugin specified, the *kubernetes* plugin will default to the zone specified in
+the server's block. It will handle all queries in that zone and connect to Kubernetes in-cluster. It
+will not provide PTR records for services or A records for pods. If **ZONES** is used it specifies
+all the zones the plugin should be authoritative for.
+
+```
+kubernetes [ZONES...] {
+    endpoint URL
+    tls CERT KEY CACERT
+    kubeconfig KUBECONFIG CONTEXT
+    namespaces NAMESPACE...
+    labels EXPRESSION
+    pods POD-MODE
+    endpoint_pod_names
+    ttl TTL
+    noendpoints
+    fallthrough [ZONES...]
+    ignore empty_service
+}
+```
+
+* `endpoint` specifies the **URL** for a remote k8s API endpoint.
+   If omitted, it will connect to k8s in-cluster using the cluster service account.
+* `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
+   This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
+* `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+* `namespaces` **NAMESPACE [NAMESPACE...]** only exposes the k8s namespaces listed.
+   If this option is omitted all namespaces are exposed
+* `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.
+   The label selector syntax is described in the
+   [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that
+   only exposes namespaces labeled as "istio-injection=enabled", would use:
+   `labels istio-injection=enabled`.
+* `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
+   The label selector syntax is described in the
+   [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that
+   only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments, would
+   use: `labels environment in (staging, qa),application=nginx`.
+* `pods` **POD-MODE** sets the mode for handling IP-based pod A records, e.g.
+   `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.
+   This option is provided to facilitate use of SSL certs when connecting directly to pods. Valid
+   values for **POD-MODE**:
+
+   * `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
+   * `insecure`: Always return an A record with IP from request (without checking k8s).  This option
+     is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This
+     option is provided for backward compatibility with kube-dns.
+   * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This
+     option requires substantially more memory than in insecure mode, since it will maintain a watch
+     on all pods.
+
+* `endpoint_pod_names` uses the pod name of the pod targeted by the endpoint as
+   the endpoint name in A records, e.g.,
+   `endpoint-name.my-service.namespace.svc.cluster.local. in A 1.2.3.4`
+   By default, the endpoint-name name selection is as follows: Use the hostname
+   of the endpoint, or if hostname is not set, use the dashed form of the endpoint
+   IP address (e.g., `1-2-3-4.my-service.namespace.svc.cluster.local.`)
+   If this directive is included, then name selection for endpoints changes as
+   follows: Use the hostname of the endpoint, or if hostname is not set, use the
+   pod name of the pod targeted by the endpoint. If there is no pod targeted by
+   the endpoint, use the dashed IP address form.
+* `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
+  0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
+* `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.
+  All endpoint queries and headless service queries will result in an NXDOMAIN.
+* `fallthrough` **[ZONES...]** If a query for a record in the zones for which the plugin is authoritative
+  results in NXDOMAIN, normally that is what the response will be. However, if you specify this option,
+  the query will instead be passed on down the plugin chain, which can include another plugin to handle
+  the query. If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
+  is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only
+  queries for those zones will be subject to fallthrough.
+* `ignore empty_service` returns NXDOMAIN for services without any ready endpoint addresses (e.g., ready pods).
+  This allows the querying pod to continue searching for the service in the search path.
+  The search path could, for example, include another Kubernetes cluster.
+
+Enabling zone transfer is done by using the *transfer* plugin.
+
+## Ready
+
+This plugin reports readiness to the ready plugin. This will happen after it has synced to the
+Kubernetes API.
+
+## Examples
+
+Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Also handle all
+`in-addr.arpa` `PTR` requests for `10.0.0.0/17` . Verify the existence of pods when answering pod
+requests.
+
+~~~ txt
+10.0.0.0/17 cluster.local {
+    kubernetes {
+        pods verified
+    }
+}
+~~~
+
+Or you can selectively expose some namespaces:
+
+~~~ txt
+kubernetes cluster.local {
+    namespaces test staging
+}
+~~~
+
+Connect to Kubernetes with CoreDNS running outside the cluster:
+
+~~~ txt
+kubernetes cluster.local {
+    endpoint https://k8s-endpoint:8443
+    tls cert key cacert
+}
+~~~
+
+## stubDomains and upstreamNameservers
+
+Here we use the *forward* plugin to implement a stubDomain that forwards `example.local` to the nameserver `10.100.0.10:53`.
+Also configured is an upstreamNameserver `8.8.8.8:53` that will be used for resolving names that do not fall in `cluster.local`
+or `example.local`.
+
+~~~ txt
+cluster.local:53 {
+    kubernetes cluster.local
+}
+example.local {
+    forward . 10.100.0.10:53
+}
+
+. {
+    forward . 8.8.8.8:53
+}
+~~~
+
+The configuration above represents the following Kube-DNS stubDomains and upstreamNameservers configuration.
+
+~~~ txt
+stubDomains: |
+   {“example.local”: [“10.100.0.10:53”]}
+upstreamNameservers: |
+   [“8.8.8.8:53”]
+~~~
+
+## AutoPath
+
+The *kubernetes* plugin can be used in conjunction with the *autopath* plugin.  Using this
+feature enables server-side domain search path completion in Kubernetes clusters.  Note: `pods` must
+be set to `verified` for this to function properly. Furthermore, the remote IP address in the DNS
+packet received by CoreDNS must be the IP address of the Pod that sent the request.
+
+    cluster.local {
+        autopath @kubernetes
+        kubernetes {
+            pods verified
+        }
+    }
+
+## Wildcards
+
+Some query labels accept a wildcard value to match any value.  If a label is a valid wildcard (\*,
+or the word "any"), then that label will match all values.  The labels that accept wildcards are:
+
+ * _endpoint_ in an `A` record request: _endpoint_.service.namespace.svc.zone, e.g., `*.nginx.ns.svc.cluster.local`
+ * _service_ in an `A` record request: _service_.namespace.svc.zone, e.g., `*.ns.svc.cluster.local`
+ * _namespace_ in an `A` record request: service._namespace_.svc.zone, e.g., `nginx.*.svc.cluster.local`
+ * _port and/or protocol_ in an `SRV` request: __port_.__protocol_.service.namespace.svc.zone.,
+   e.g., `_http.*.service.ns.svc.cluster.local`
+ * multiple wildcards are allowed in a single query, e.g., `A` Request `*.*.svc.zone.` or `SRV` request `*.*.*.*.svc.zone.`
+
+ For example, wildcards can be used to resolve all Endpoints for a Service as `A` records. e.g.: `*.service.ns.svc.myzone.local` will return the Endpoint IPs in the Service `service` in namespace `default`:
+
+```
+*.service.default.svc.cluster.local. 5	IN A	192.168.10.10
+*.service.default.svc.cluster.local. 5	IN A	192.168.25.15
+```
+
+## Metadata
+
+The kubernetes plugin will publish the following metadata, if the *metadata*
+plugin is also enabled:
+
+ * `kubernetes/endpoint`: the endpoint name in the query
+ * `kubernetes/kind`: the resource kind (pod or svc) in the query
+ * `kubernetes/namespace`: the namespace in the query
+ * `kubernetes/port-name`: the port name in an SRV query
+ * `kubernetes/protocol`: the protocol in an SRV query
+ * `kubernetes/service`: the service name in the query
+ * `kubernetes/client-namespace`: the client pod's namespace (see requirements below)
+ * `kubernetes/client-pod-name`: the client pod's name (see requirements below)
+
+The `kubernetes/client-namespace` and `kubernetes/client-pod-name` metadata work by reconciling the
+client IP address in the DNS request packet to a known pod IP address. Therefore the following is required:
+ * `pods verified` mode must be enabled
+ * the remote IP address in the DNS packet received by CoreDNS must be the IP address
+   of the Pod that sent the request.
+
+## Metrics
+
+If monitoring is enabled (via the *prometheus* plugin) then the following metrics are exported:
+
+* `coredns_kubernetes_dns_programming_duration_seconds{service_kind}` - Exports the
+  [DNS programming latency SLI](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/dns_programming_latency.md).
+  The metrics has the `service_kind` label that identifies the kind of the
+  [kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service).
+  It may take one of the three values:
+    * `cluster_ip`
+    * `headless_with_selector`
+    * `headless_without_selector`
+
+## Bugs
+
+The duration metric only supports the "headless\_with\_selector" service currently.
+
+## Also See
+
+See the *autopath* plugin to enable search path optimizations. And use the *transfer* plugin to
+enable outgoing zone transfers.

--- a/coredns/plugin/kubernetes/autopath.go
+++ b/coredns/plugin/kubernetes/autopath.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/request"
+)
+
+// AutoPath implements the AutoPathFunc call from the autopath plugin.
+// It returns a per-query search path or nil indicating no searchpathing should happen.
+func (k *Kubernetes) AutoPath(state request.Request) []string {
+	// Check if the query falls in a zone we are actually authoritative for and thus if we want autopath.
+	zone := plugin.Zones(k.Zones).Matches(state.Name())
+	if zone == "" {
+		return nil
+	}
+
+	// cluster.local {
+	//    autopath @kubernetes
+	//    kubernetes {
+	//        pods verified #
+	//    }
+	// }
+	// if pods != verified will cause panic and return SERVFAIL, expect worked as normal without autopath function
+	if !k.opts.initPodCache {
+		return nil
+	}
+
+	ip := state.IP()
+
+	pod := k.podWithIP(ip)
+	if pod == nil {
+		return nil
+	}
+
+	search := make([]string, 3)
+	if zone == "." {
+		search[0] = pod.Namespace + ".svc."
+		search[1] = "svc."
+		search[2] = "."
+	} else {
+		search[0] = pod.Namespace + ".svc." + zone
+		search[1] = "svc." + zone
+		search[2] = zone
+	}
+
+	search = append(search, k.autoPathSearch...)
+	search = append(search, "") // sentinel
+	return search
+}
+
+// podWithIP returns the api.Pod for source IP. It returns nil if nothing can be found.
+func (k *Kubernetes) podWithIP(ip string) *object.Pod {
+	if k.podMode != podModeVerified {
+		return nil
+	}
+	ps := k.APIConn.PodIndex(ip)
+	if len(ps) == 0 {
+		return nil
+	}
+	return ps[0]
+}

--- a/coredns/plugin/kubernetes/controller.go
+++ b/coredns/plugin/kubernetes/controller.go
@@ -1,0 +1,523 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	podIPIndex            = "PodIP"
+	svcNameNamespaceIndex = "NameNamespace"
+	svcIPIndex            = "ServiceIP"
+	epNameNamespaceIndex  = "EndpointNameNamespace"
+	epIPIndex             = "EndpointsIP"
+)
+
+type dnsController interface {
+	ServiceList() []*object.Service
+	EndpointsList() []*object.Endpoints
+	SvcIndex(string) []*object.Service
+	SvcIndexReverse(string) []*object.Service
+	PodIndex(string) []*object.Pod
+	EpIndex(string) []*object.Endpoints
+	EpIndexReverse(string) []*object.Endpoints
+
+	GetNodeByName(context.Context, string) (*api.Node, error)
+	GetNamespaceByName(string) (*api.Namespace, error)
+
+	Run()
+	HasSynced() bool
+	Stop() error
+
+	// Modified returns the timestamp of the most recent changes
+	Modified() int64
+}
+
+type dnsControl struct {
+	// Modified tracks timestamp of the most recent changes
+	// It needs to be first because it is guaranteed to be 8-byte
+	// aligned ( we use sync.LoadAtomic with this )
+	modified int64
+
+	client kubernetes.Interface
+
+	selector          labels.Selector
+	namespaceSelector labels.Selector
+
+	svcController cache.Controller
+	podController cache.Controller
+	epController  cache.Controller
+	nsController  cache.Controller
+
+	svcLister cache.Indexer
+	podLister cache.Indexer
+	epLister  cache.Indexer
+	nsLister  cache.Store
+
+	// stopLock is used to enforce only a single call to Stop is active.
+	// Needed because we allow stopping through an http endpoint and
+	// allowing concurrent stoppers leads to stack traces.
+	stopLock sync.Mutex
+	shutdown bool
+	stopCh   chan struct{}
+
+	zones            []string
+	endpointNameMode bool
+}
+
+type dnsControlOpts struct {
+	initPodCache       bool
+	initEndpointsCache bool
+	ignoreEmptyService bool
+
+	// Label handling.
+	labelSelector          *meta.LabelSelector
+	selector               labels.Selector
+	namespaceLabelSelector *meta.LabelSelector
+	namespaceSelector      labels.Selector
+
+	zones                 []string
+	endpointNameMode      bool
+	skipAPIObjectsCleanup bool
+}
+
+// newDNSController creates a controller for CoreDNS.
+func newdnsController(ctx context.Context, kubeClient kubernetes.Interface, opts dnsControlOpts) *dnsControl {
+	dns := dnsControl{
+		client:            kubeClient,
+		selector:          opts.selector,
+		namespaceSelector: opts.namespaceSelector,
+		stopCh:            make(chan struct{}),
+		zones:             opts.zones,
+		endpointNameMode:  opts.endpointNameMode,
+	}
+
+	dns.svcLister, dns.svcController = object.NewIndexerInformer(
+		&cache.ListWatch{
+			ListFunc:  serviceListFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+			WatchFunc: serviceWatchFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+		},
+		&api.Service{},
+		cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
+		cache.Indexers{svcNameNamespaceIndex: svcNameNamespaceIndexFunc, svcIPIndex: svcIPIndexFunc},
+		object.DefaultProcessor(object.ToService(opts.skipAPIObjectsCleanup), nil),
+	)
+
+	if opts.initPodCache {
+		dns.podLister, dns.podController = object.NewIndexerInformer(
+			&cache.ListWatch{
+				ListFunc:  podListFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+				WatchFunc: podWatchFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+			},
+			&api.Pod{},
+			cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
+			cache.Indexers{podIPIndex: podIPIndexFunc},
+			object.DefaultProcessor(object.ToPod(opts.skipAPIObjectsCleanup), nil),
+		)
+	}
+
+	if opts.initEndpointsCache {
+		dns.epLister, dns.epController = object.NewIndexerInformer(
+			&cache.ListWatch{
+				ListFunc:  endpointsListFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+				WatchFunc: endpointsWatchFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+			},
+			&api.Endpoints{},
+			cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
+			cache.Indexers{epNameNamespaceIndex: epNameNamespaceIndexFunc, epIPIndex: epIPIndexFunc},
+			object.DefaultProcessor(object.ToEndpoints(opts.skipAPIObjectsCleanup), dns.recordDNSProgrammingLatency),
+		)
+	}
+
+	dns.nsLister, dns.nsController = cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc:  namespaceListFunc(ctx, dns.client, dns.namespaceSelector),
+			WatchFunc: namespaceWatchFunc(ctx, dns.client, dns.namespaceSelector),
+		},
+		&api.Namespace{},
+		defaultResyncPeriod,
+		cache.ResourceEventHandlerFuncs{})
+
+	return &dns
+}
+
+func (dns *dnsControl) recordDNSProgrammingLatency(obj meta.Object) {
+	recordDNSProgrammingLatency(dns.getServices(obj.(*api.Endpoints)), obj.(*api.Endpoints))
+}
+
+func podIPIndexFunc(obj interface{}) ([]string, error) {
+	p, ok := obj.(*object.Pod)
+	if !ok {
+		return nil, errObj
+	}
+	return []string{p.PodIP}, nil
+}
+
+func svcIPIndexFunc(obj interface{}) ([]string, error) {
+	svc, ok := obj.(*object.Service)
+	if !ok {
+		return nil, errObj
+	}
+	if len(svc.ExternalIPs) == 0 {
+		return []string{svc.ClusterIP}, nil
+	}
+
+	return append([]string{svc.ClusterIP}, svc.ExternalIPs...), nil
+}
+
+func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+	s, ok := obj.(*object.Service)
+	if !ok {
+		return nil, errObj
+	}
+	return []string{s.Index}, nil
+}
+
+func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+	s, ok := obj.(*object.Endpoints)
+	if !ok {
+		return nil, errObj
+	}
+	return []string{s.Index}, nil
+}
+
+func epIPIndexFunc(obj interface{}) ([]string, error) {
+	ep, ok := obj.(*object.Endpoints)
+	if !ok {
+		return nil, errObj
+	}
+	return ep.IndexIP, nil
+}
+
+func serviceListFunc(ctx context.Context, c kubernetes.Interface, ns string, s labels.Selector) func(meta.ListOptions) (runtime.Object, error) {
+	return func(opts meta.ListOptions) (runtime.Object, error) {
+		if s != nil {
+			opts.LabelSelector = s.String()
+		}
+		listV1, err := c.CoreV1().Services(ns).List(ctx, opts)
+		return listV1, err
+	}
+}
+
+func podListFunc(ctx context.Context, c kubernetes.Interface, ns string, s labels.Selector) func(meta.ListOptions) (runtime.Object, error) {
+	return func(opts meta.ListOptions) (runtime.Object, error) {
+		if s != nil {
+			opts.LabelSelector = s.String()
+		}
+		if len(opts.FieldSelector) > 0 {
+			opts.FieldSelector = opts.FieldSelector + ","
+		}
+		opts.FieldSelector = opts.FieldSelector + "status.phase!=Succeeded,status.phase!=Failed,status.phase!=Unknown"
+		listV1, err := c.CoreV1().Pods(ns).List(ctx, opts)
+		return listV1, err
+	}
+}
+
+func endpointsListFunc(ctx context.Context, c kubernetes.Interface, ns string, s labels.Selector) func(meta.ListOptions) (runtime.Object, error) {
+	return func(opts meta.ListOptions) (runtime.Object, error) {
+		if s != nil {
+			opts.LabelSelector = s.String()
+		}
+		listV1, err := c.CoreV1().Endpoints(ns).List(ctx, opts)
+		return listV1, err
+	}
+}
+
+func namespaceListFunc(ctx context.Context, c kubernetes.Interface, s labels.Selector) func(meta.ListOptions) (runtime.Object, error) {
+	return func(opts meta.ListOptions) (runtime.Object, error) {
+		if s != nil {
+			opts.LabelSelector = s.String()
+		}
+		listV1, err := c.CoreV1().Namespaces().List(ctx, opts)
+		return listV1, err
+	}
+}
+
+// Stop stops the  controller.
+func (dns *dnsControl) Stop() error {
+	dns.stopLock.Lock()
+	defer dns.stopLock.Unlock()
+
+	// Only try draining the workqueue if we haven't already.
+	if !dns.shutdown {
+		close(dns.stopCh)
+		dns.shutdown = true
+
+		return nil
+	}
+
+	return fmt.Errorf("shutdown already in progress")
+}
+
+// Run starts the controller.
+func (dns *dnsControl) Run() {
+	go dns.svcController.Run(dns.stopCh)
+	if dns.epController != nil {
+		go dns.epController.Run(dns.stopCh)
+	}
+	if dns.podController != nil {
+		go dns.podController.Run(dns.stopCh)
+	}
+	go dns.nsController.Run(dns.stopCh)
+	<-dns.stopCh
+}
+
+// HasSynced calls on all controllers.
+func (dns *dnsControl) HasSynced() bool {
+	a := dns.svcController.HasSynced()
+	b := true
+	if dns.epController != nil {
+		b = dns.epController.HasSynced()
+	}
+	c := true
+	if dns.podController != nil {
+		c = dns.podController.HasSynced()
+	}
+	d := dns.nsController.HasSynced()
+	return a && b && c && d
+}
+
+func (dns *dnsControl) ServiceList() (svcs []*object.Service) {
+	os := dns.svcLister.List()
+	for _, o := range os {
+		s, ok := o.(*object.Service)
+		if !ok {
+			continue
+		}
+		svcs = append(svcs, s)
+	}
+	return svcs
+}
+
+func (dns *dnsControl) EndpointsList() (eps []*object.Endpoints) {
+	os := dns.epLister.List()
+	for _, o := range os {
+		ep, ok := o.(*object.Endpoints)
+		if !ok {
+			continue
+		}
+		eps = append(eps, ep)
+	}
+	return eps
+}
+
+func (dns *dnsControl) PodIndex(ip string) (pods []*object.Pod) {
+	os, err := dns.podLister.ByIndex(podIPIndex, ip)
+	if err != nil {
+		return nil
+	}
+	for _, o := range os {
+		p, ok := o.(*object.Pod)
+		if !ok {
+			continue
+		}
+		pods = append(pods, p)
+	}
+	return pods
+}
+
+func (dns *dnsControl) SvcIndex(idx string) (svcs []*object.Service) {
+	os, err := dns.svcLister.ByIndex(svcNameNamespaceIndex, idx)
+	if err != nil {
+		return nil
+	}
+	for _, o := range os {
+		s, ok := o.(*object.Service)
+		if !ok {
+			continue
+		}
+		svcs = append(svcs, s)
+	}
+	return svcs
+}
+
+func (dns *dnsControl) SvcIndexReverse(ip string) (svcs []*object.Service) {
+	os, err := dns.svcLister.ByIndex(svcIPIndex, ip)
+	if err != nil {
+		return nil
+	}
+
+	for _, o := range os {
+		s, ok := o.(*object.Service)
+		if !ok {
+			continue
+		}
+		svcs = append(svcs, s)
+	}
+	return svcs
+}
+
+func (dns *dnsControl) EpIndex(idx string) (ep []*object.Endpoints) {
+	os, err := dns.epLister.ByIndex(epNameNamespaceIndex, idx)
+	if err != nil {
+		return nil
+	}
+	for _, o := range os {
+		e, ok := o.(*object.Endpoints)
+		if !ok {
+			continue
+		}
+		ep = append(ep, e)
+	}
+	return ep
+}
+
+func (dns *dnsControl) EpIndexReverse(ip string) (ep []*object.Endpoints) {
+	os, err := dns.epLister.ByIndex(epIPIndex, ip)
+	if err != nil {
+		return nil
+	}
+	for _, o := range os {
+		e, ok := o.(*object.Endpoints)
+		if !ok {
+			continue
+		}
+		ep = append(ep, e)
+	}
+	return ep
+}
+
+// GetNodeByName return the node by name. If nothing is found an error is
+// returned. This query causes a roundtrip to the k8s API server, so use
+// sparingly. Currently this is only used for Federation.
+func (dns *dnsControl) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+	v1node, err := dns.client.CoreV1().Nodes().Get(ctx, name, meta.GetOptions{})
+	return v1node, err
+}
+
+// GetNamespaceByName returns the namespace by name. If nothing is found an error is returned.
+func (dns *dnsControl) GetNamespaceByName(name string) (*api.Namespace, error) {
+	os := dns.nsLister.List()
+	for _, o := range os {
+		ns, ok := o.(*api.Namespace)
+		if !ok {
+			continue
+		}
+		if name == ns.ObjectMeta.Name {
+			return ns, nil
+		}
+	}
+	return nil, fmt.Errorf("namespace not found")
+}
+
+func (dns *dnsControl) Add(obj interface{})               { dns.updateModifed() }
+func (dns *dnsControl) Delete(obj interface{})            { dns.updateModifed() }
+func (dns *dnsControl) Update(oldObj, newObj interface{}) { dns.detectChanges(oldObj, newObj) }
+
+// detectChanges detects changes in objects, and updates the modified timestamp
+func (dns *dnsControl) detectChanges(oldObj, newObj interface{}) {
+	// If both objects have the same resource version, they are identical.
+	if newObj != nil && oldObj != nil && (oldObj.(meta.Object).GetResourceVersion() == newObj.(meta.Object).GetResourceVersion()) {
+		return
+	}
+	obj := newObj
+	if obj == nil {
+		obj = oldObj
+	}
+	switch ob := obj.(type) {
+	case *object.Service:
+		dns.updateModifed()
+	case *object.Pod:
+		dns.updateModifed()
+	case *object.Endpoints:
+		if !endpointsEquivalent(oldObj.(*object.Endpoints), newObj.(*object.Endpoints)) {
+			dns.updateModifed()
+		}
+	default:
+		log.Warningf("Updates for %T not supported.", ob)
+	}
+}
+
+func (dns *dnsControl) getServices(endpoints *api.Endpoints) []*object.Service {
+	return dns.SvcIndex(object.EndpointsKey(endpoints.GetName(), endpoints.GetNamespace()))
+}
+
+// subsetsEquivalent checks if two endpoint subsets are significantly equivalent
+// I.e. that they have the same ready addresses, host names, ports (including protocol
+// and service names for SRV)
+func subsetsEquivalent(sa, sb object.EndpointSubset) bool {
+	if len(sa.Addresses) != len(sb.Addresses) {
+		return false
+	}
+	if len(sa.Ports) != len(sb.Ports) {
+		return false
+	}
+
+	// in Addresses and Ports, we should be able to rely on
+	// these being sorted and able to be compared
+	// they are supposed to be in a canonical format
+	for addr, aaddr := range sa.Addresses {
+		baddr := sb.Addresses[addr]
+		if aaddr.IP != baddr.IP {
+			return false
+		}
+		if aaddr.Hostname != baddr.Hostname {
+			return false
+		}
+	}
+
+	for port, aport := range sa.Ports {
+		bport := sb.Ports[port]
+		if aport.Name != bport.Name {
+			return false
+		}
+		if aport.Port != bport.Port {
+			return false
+		}
+		if aport.Protocol != bport.Protocol {
+			return false
+		}
+	}
+	return true
+}
+
+// endpointsEquivalent checks if the update to an endpoint is something
+// that matters to us or if they are effectively equivalent.
+func endpointsEquivalent(a, b *object.Endpoints) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	if len(a.Subsets) != len(b.Subsets) {
+		return false
+	}
+
+	// we should be able to rely on
+	// these being sorted and able to be compared
+	// they are supposed to be in a canonical format
+	for i, sa := range a.Subsets {
+		sb := b.Subsets[i]
+		if !subsetsEquivalent(sa, sb) {
+			return false
+		}
+	}
+	return true
+}
+
+func (dns *dnsControl) Modified() int64 {
+	unix := atomic.LoadInt64(&dns.modified)
+	return unix
+}
+
+// updateModified set dns.modified to the current time.
+func (dns *dnsControl) updateModifed() {
+	unix := time.Now().Unix()
+	atomic.StoreInt64(&dns.modified, unix)
+}
+
+var errObj = errors.New("obj was not of the correct type")
+
+const defaultResyncPeriod = 0

--- a/coredns/plugin/kubernetes/controller_test.go
+++ b/coredns/plugin/kubernetes/controller_test.go
@@ -1,0 +1,172 @@
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
+
+func BenchmarkController(b *testing.B) {
+	client := fake.NewSimpleClientset()
+	dco := dnsControlOpts{
+		zones: []string{"cluster.local."},
+	}
+	ctx := context.Background()
+	controller := newdnsController(ctx, client, dco)
+	cidr := "10.0.0.0/19"
+
+	// Add resources
+	generateEndpoints(cidr, client)
+	generateSvcs(cidr, "all", client)
+	m := new(dns.Msg)
+	m.SetQuestion("svc1.testns.svc.cluster.local.", dns.TypeA)
+	k := New([]string{"cluster.local."})
+	k.APIConn = controller
+	rw := &test.ResponseWriter{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		k.ServeDNS(ctx, rw, m)
+	}
+}
+
+func generateEndpoints(cidr string, client kubernetes.Interface) {
+	// https://groups.google.com/d/msg/golang-nuts/zlcYA4qk-94/TWRFHeXJCcYJ
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	count := 1
+	ep := &api.Endpoints{
+		Subsets: []api.EndpointSubset{{
+			Ports: []api.EndpointPort{
+				{
+					Port:     80,
+					Protocol: "tcp",
+					Name:     "http",
+				},
+			},
+		}},
+		ObjectMeta: meta.ObjectMeta{
+			Namespace: "testns",
+		},
+	}
+	ctx := context.TODO()
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+		ep.Subsets[0].Addresses = []api.EndpointAddress{
+			{
+				IP:       ip.String(),
+				Hostname: "foo" + strconv.Itoa(count),
+			},
+		}
+		ep.ObjectMeta.Name = "svc" + strconv.Itoa(count)
+		client.CoreV1().Endpoints("testns").Create(ctx, ep, meta.CreateOptions{})
+		count++
+	}
+}
+
+func generateSvcs(cidr string, svcType string, client kubernetes.Interface) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	count := 1
+	switch svcType {
+	case "clusterip":
+		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+			createClusterIPSvc(count, client, ip)
+			count++
+		}
+	case "headless":
+		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+			createHeadlessSvc(count, client, ip)
+			count++
+		}
+	case "external":
+		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+			createExternalSvc(count, client, ip)
+			count++
+		}
+	default:
+		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+			if count%3 == 0 {
+				createClusterIPSvc(count, client, ip)
+			} else if count%3 == 1 {
+				createHeadlessSvc(count, client, ip)
+			} else if count%3 == 2 {
+				createExternalSvc(count, client, ip)
+			}
+			count++
+		}
+	}
+}
+
+func createClusterIPSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+	ctx := context.TODO()
+	client.CoreV1().Services("testns").Create(ctx, &api.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc" + strconv.Itoa(suffix),
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ClusterIP: ip.String(),
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
+		},
+	}, meta.CreateOptions{})
+}
+
+func createHeadlessSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+	ctx := context.TODO()
+	client.CoreV1().Services("testns").Create(ctx, &api.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "hdls" + strconv.Itoa(suffix),
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ClusterIP: api.ClusterIPNone,
+		},
+	}, meta.CreateOptions{})
+}
+
+func createExternalSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+	ctx := context.TODO()
+	client.CoreV1().Services("testns").Create(ctx, &api.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "external" + strconv.Itoa(suffix),
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ExternalName: "coredns" + strconv.Itoa(suffix) + ".io",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
+			Type: api.ServiceTypeExternalName,
+		},
+	}, meta.CreateOptions{})
+}

--- a/coredns/plugin/kubernetes/external.go
+++ b/coredns/plugin/kubernetes/external.go
@@ -1,0 +1,94 @@
+package kubernetes
+
+import (
+	"strings"
+
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// External implements the ExternalFunc call from the external plugin.
+// It returns any services matching in the services' ExternalIPs.
+func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
+	base, _ := dnsutil.TrimZone(state.Name(), state.Zone)
+
+	segs := dns.SplitDomainName(base)
+	last := len(segs) - 1
+	if last < 0 {
+		return nil, dns.RcodeServerFailure
+	}
+	// We are dealing with a fairly normal domain name here, but we still need to have the service
+	// and the namespace:
+	// service.namespace.<base>
+	//
+	// for service (and SRV) you can also say _tcp, and port (i.e. _http), we need those be picked
+	// up, unless they are not specified, then we use an internal wildcard.
+	port := "*"
+	protocol := "*"
+	namespace := segs[last]
+	if !k.namespaceExposed(namespace) {
+		return nil, dns.RcodeNameError
+	}
+
+	last--
+	if last < 0 {
+		return nil, dns.RcodeSuccess
+	}
+
+	service := segs[last]
+	last--
+	if last == 1 {
+		protocol = stripUnderscore(segs[last])
+		port = stripUnderscore(segs[last-1])
+		last -= 2
+	}
+
+	if last != -1 {
+		// too long
+		return nil, dns.RcodeNameError
+	}
+
+	idx := object.ServiceKey(service, namespace)
+	serviceList := k.APIConn.SvcIndex(idx)
+
+	services := []msg.Service{}
+	zonePath := msg.Path(state.Zone, coredns)
+	rcode := dns.RcodeNameError
+
+	for _, svc := range serviceList {
+		if namespace != svc.Namespace {
+			continue
+		}
+		if service != svc.Name {
+			continue
+		}
+
+		for _, ip := range svc.ExternalIPs {
+			for _, p := range svc.Ports {
+				if !(match(port, p.Name) && match(protocol, string(p.Protocol))) {
+					continue
+				}
+				rcode = dns.RcodeSuccess
+				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+
+				services = append(services, s)
+			}
+		}
+	}
+	return services, rcode
+}
+
+// ExternalAddress returns the external service address(es) for the CoreDNS service.
+func (k *Kubernetes) ExternalAddress(state request.Request) []dns.RR {
+	// If CoreDNS is running inside the Kubernetes cluster: k.nsAddrs() will return the external IPs of the services
+	// targeting the CoreDNS Pod.
+	// If CoreDNS is running outside of the Kubernetes cluster: k.nsAddrs() will return the first non-loopback IP
+	// address seen on the local system it is running on. This could be the wrong answer if coredns is using the *bind*
+	// plugin to bind to a different IP address.
+	return k.nsAddrs(true, state.Zone)
+}

--- a/coredns/plugin/kubernetes/external_test.go
+++ b/coredns/plugin/kubernetes/external_test.go
@@ -1,0 +1,136 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var extCases = []struct {
+	Qname string
+	Qtype uint16
+	Msg   []msg.Service
+	Rcode int
+}{
+	{
+		Qname: "svc1.testns.example.org.", Rcode: dns.RcodeSuccess,
+		Msg: []msg.Service{
+			{Host: "1.2.3.4", Port: 80, TTL: 5, Key: "/c/org/example/testns/svc1"},
+		},
+	},
+	{
+		Qname: "svc6.testns.example.org.", Rcode: dns.RcodeSuccess,
+		Msg: []msg.Service{
+			{Host: "1:2::5", Port: 80, TTL: 5, Key: "/c/org/example/testns/svc1"},
+		},
+	},
+	{
+		Qname: "*._not-udp-or-tcp.svc1.testns.example.com.", Rcode: dns.RcodeSuccess,
+	},
+	{
+		Qname: "_http._tcp.svc1.testns.example.com.", Rcode: dns.RcodeSuccess,
+		Msg: []msg.Service{
+			{Host: "1.2.3.4", Port: 80, TTL: 5, Key: "/c/org/example/testns/svc1"},
+		},
+	},
+	{
+		Qname: "svc0.testns.example.com.", Rcode: dns.RcodeNameError,
+	},
+	{
+		Qname: "svc0.svc-nons.example.com.", Rcode: dns.RcodeNameError,
+	},
+}
+
+func TestExternal(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &external{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.Namespaces = map[string]struct{}{"testns": {}}
+
+	for i, tc := range extCases {
+		state := testRequest(tc.Qname)
+
+		svc, rcode := k.External(state)
+
+		if x := tc.Rcode; x != rcode {
+			t.Errorf("Test %d, expected rcode %d, got %d", i, x, rcode)
+		}
+
+		if len(svc) != len(tc.Msg) {
+			t.Errorf("Test %d, expected %d for messages, got %d", i, len(tc.Msg), len(svc))
+		}
+
+		for j, s := range svc {
+			if x := tc.Msg[j].Key; x != s.Key {
+				t.Errorf("Test %d, expected key %s, got %s", i, x, s.Key)
+			}
+			return
+		}
+	}
+}
+
+type external struct{}
+
+func (external) HasSynced() bool                                                   { return true }
+func (external) Run()                                                              {}
+func (external) Stop() error                                                       { return nil }
+func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
+func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
+func (external) Modified() int64                                                   { return 0 }
+func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
+func (external) EndpointsList() []*object.Endpoints                                { return nil }
+func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
+func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
+func (external) PodIndex(string) []*object.Pod                                     { return nil }
+
+func (external) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}
+
+var svcIndexExternal = map[string][]*object.Service{
+	"svc1.testns": {
+		{
+			Name:        "svc1",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeClusterIP,
+			ClusterIP:   "10.0.0.1",
+			ExternalIPs: []string{"1.2.3.4"},
+			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	},
+	"svc6.testns": {
+		{
+			Name:        "svc6",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeClusterIP,
+			ClusterIP:   "10.0.0.3",
+			ExternalIPs: []string{"1:2::5"},
+			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	},
+}
+
+func (external) ServiceList() []*object.Service {
+	var svcs []*object.Service
+	for _, svc := range svcIndexExternal {
+		svcs = append(svcs, svc...)
+	}
+	return svcs
+}
+
+func testRequest(name string) request.Request {
+	m := new(dns.Msg).SetQuestion(name, dns.TypeA)
+	return request.Request{W: &test.ResponseWriter{}, Req: m, Zone: "example.org."}
+}

--- a/coredns/plugin/kubernetes/handler.go
+++ b/coredns/plugin/kubernetes/handler.go
@@ -1,0 +1,89 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// ServeDNS implements the plugin.Handler interface.
+func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+
+	qname := state.QName()
+	zone := plugin.Zones(k.Zones).Matches(qname)
+	if zone == "" {
+		return plugin.NextOrFailure(k.Name(), k.Next, ctx, w, r)
+	}
+	zone = qname[len(qname)-len(zone):] // maintain case of original query
+	state.Zone = zone
+
+	var (
+		records []dns.RR
+		extra   []dns.RR
+		err     error
+	)
+
+	switch state.QType() {
+	case dns.TypeA:
+		records, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
+	case dns.TypeAAAA:
+		records, err = plugin.AAAA(ctx, &k, zone, state, nil, plugin.Options{})
+	case dns.TypeTXT:
+		records, err = plugin.TXT(ctx, &k, zone, state, nil, plugin.Options{})
+	case dns.TypeCNAME:
+		records, err = plugin.CNAME(ctx, &k, zone, state, plugin.Options{})
+	case dns.TypePTR:
+		records, err = plugin.PTR(ctx, &k, zone, state, plugin.Options{})
+	case dns.TypeMX:
+		records, extra, err = plugin.MX(ctx, &k, zone, state, plugin.Options{})
+	case dns.TypeSRV:
+		records, extra, err = plugin.SRV(ctx, &k, zone, state, plugin.Options{})
+	case dns.TypeSOA:
+		records, err = plugin.SOA(ctx, &k, zone, state, plugin.Options{})
+	case dns.TypeNS:
+		if state.Name() == zone {
+			records, extra, err = plugin.NS(ctx, &k, zone, state, plugin.Options{})
+			break
+		}
+		fallthrough
+	default:
+		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
+		fake := state.NewWithQuestion(state.QName(), dns.TypeA)
+		fake.Zone = state.Zone
+		_, err = plugin.A(ctx, &k, zone, fake, nil, plugin.Options{})
+	}
+
+	if k.IsNameError(err) {
+		if k.Fall.Through(state.Name()) {
+			return plugin.NextOrFailure(k.Name(), k.Next, ctx, w, r)
+		}
+		if !k.APIConn.HasSynced() {
+			// If we haven't synchronized with the kubernetes cluster, return server failure
+			return plugin.BackendError(ctx, &k, zone, dns.RcodeServerFailure, state, nil /* err */, plugin.Options{})
+		}
+		return plugin.BackendError(ctx, &k, zone, dns.RcodeNameError, state, nil /* err */, plugin.Options{})
+	}
+	if err != nil {
+		return dns.RcodeServerFailure, err
+	}
+
+	if len(records) == 0 {
+		return plugin.BackendError(ctx, &k, zone, dns.RcodeSuccess, state, nil, plugin.Options{})
+	}
+
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Authoritative = true
+	m.Answer = append(m.Answer, records...)
+	m.Extra = append(m.Extra, extra...)
+
+	w.WriteMsg(m)
+	return dns.RcodeSuccess, nil
+}
+
+// Name implements the Handler interface.
+func (k Kubernetes) Name() string { return "kubernetes" }

--- a/coredns/plugin/kubernetes/handler_case_test.go
+++ b/coredns/plugin/kubernetes/handler_case_test.go
@@ -1,0 +1,73 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsPreserveCaseCases = []test.Case{
+	// Negative response
+	{
+		Qname: "not-a-service.testns.svc.ClUsTeR.lOcAl.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("ClUsTeR.lOcAl.	5	IN	SOA	ns.dns.ClUsTeR.lOcAl. hostmaster.ClUsTeR.lOcAl. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// A Service
+	{
+		Qname: "SvC1.TeStNs.SvC.cLuStEr.LoCaL.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("SvC1.TeStNs.SvC.cLuStEr.LoCaL.	5	IN	A	10.0.0.1"),
+		},
+	},
+	// SRV Service
+	{
+		Qname: "_HtTp._TcP.sVc1.TeStNs.SvC.cLuStEr.LoCaL.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_HtTp._TcP.sVc1.TeStNs.SvC.cLuStEr.LoCaL.	5	IN	SRV	0 100 80 svc1.testns.svc.cLuStEr.LoCaL."),
+		},
+		Extra: []dns.RR{
+			test.A("svc1.testns.svc.cLuStEr.LoCaL.	5	IN	A	10.0.0.1"),
+		},
+	},
+}
+
+func TestPreserveCase(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.opts.ignoreEmptyService = true
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	ctx := context.TODO()
+
+	for i, tc := range dnsPreserveCaseCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/handler_ignore_emptyservice_test.go
+++ b/coredns/plugin/kubernetes/handler_ignore_emptyservice_test.go
@@ -1,0 +1,68 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsEmptyServiceTestCases = []test.Case{
+	// A Service
+	{
+		Qname: "svcempty.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// CNAME to external
+	{
+		Qname: "external.testns.svc.cluster.local.", Qtype: dns.TypeCNAME,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
+		},
+	},
+}
+
+func TestServeDNSEmptyService(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.opts.ignoreEmptyService = true
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	ctx := context.TODO()
+
+	for i, tc := range dnsEmptyServiceTestCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		// Before sorting, make sure that CNAMES do not appear after their target records
+		if err := test.CNAMEOrder(resp); err != nil {
+			t.Error(err)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/handler_pod_disabled_test.go
+++ b/coredns/plugin/kubernetes/handler_pod_disabled_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var podModeDisabledCases = []test.Case{
+	{
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+}
+
+func TestServeDNSModeDisabled(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.podMode = podModeDisabled
+	ctx := context.TODO()
+
+	for i, tc := range podModeDisabledCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d got unexpected error %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/handler_pod_insecure_test.go
+++ b/coredns/plugin/kubernetes/handler_pod_insecure_test.go
@@ -1,0 +1,96 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var podModeInsecureCases = []test.Case{
+	{
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-240-0-1.podns.pod.cluster.local.	5	IN	A	10.240.0.1"),
+		},
+	},
+	{
+		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("172-0-0-2.podns.pod.cluster.local.	5	IN	A	172.0.0.2"),
+		},
+	},
+	{
+		Qname: "blah.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1515173576 7200 1800 86400 30"),
+		},
+	},
+	{
+		Qname: "blah.podns.pod.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1515173576 7200 1800 86400 30"),
+		},
+	},
+	{
+		Qname: "blah.podns.pod.cluster.local.", Qtype: dns.TypeHINFO,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1515173576 7200 1800 86400 30"),
+		},
+	},
+	{
+		Qname: "blah.pod-nons.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1515173576 7200 1800 86400 30"),
+		},
+	},
+	{
+		Qname: "podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1515173576 7200 1800 86400 30"),
+		},
+	},
+}
+
+func TestServeDNSModeInsecure(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	ctx := context.TODO()
+	k.podMode = podModeInsecure
+
+	for i, tc := range podModeInsecureCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/handler_pod_verified_test.go
+++ b/coredns/plugin/kubernetes/handler_pod_verified_test.go
@@ -1,0 +1,82 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var podModeVerifiedCases = []test.Case{
+	{
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-240-0-1.podns.pod.cluster.local.	5	IN	A	10.240.0.1"),
+		},
+	},
+	{
+		Qname: "podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "svcns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "pod-nons.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+}
+
+func TestServeDNSModeVerified(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	ctx := context.TODO()
+	k.podMode = podModeVerified
+
+	for i, tc := range podModeVerifiedCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/handler_test.go
+++ b/coredns/plugin/kubernetes/handler_test.go
@@ -1,0 +1,726 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var dnsTestCases = []test.Case{
+	// A Service
+	{
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	{
+		Qname: "svcempty.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svcempty.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	// A Service (wildcard)
+	{
+		Qname: "svc1.*.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.*.svc.cluster.local.  5       IN      A       10.0.0.1"),
+		},
+	},
+	{
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svc1.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
+		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+	},
+	{
+		Qname: "svcempty.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svcempty.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.")},
+		Extra: []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+	},
+	{
+		Qname: "svc6.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svc6.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc6.testns.svc.cluster.local.")},
+		Extra: []dns.RR{test.AAAA("svc6.testns.svc.cluster.local.  5       IN      AAAA       1234:abcd::1")},
+	},
+	// SRV Service (wildcard)
+	{
+		Qname: "svc1.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svc1.*.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
+		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+	},
+	{
+		Qname: "svcempty.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svcempty.*.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.")},
+		Extra: []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+	},
+	// SRV Service (wildcards)
+	{
+		Qname: "*.any.svc1.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("*.any.svc1.*.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
+		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+	},
+	// A Service (wildcards)
+	{
+		Qname: "*.any.svc1.*.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("*.any.svc1.*.svc.cluster.local.  5       IN      A       10.0.0.1"),
+		},
+	},
+	// SRV Service Not udp/tcp
+	{
+		Qname: "*._not-udp-or-tcp.svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// SRV Service
+	{
+		Qname: "_http._tcp.svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc1.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	{
+		Qname: "_http._tcp.svcempty.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svcempty.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svcempty.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	// A Service (Headless)
+	{
+		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2"),
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3"),
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
+		},
+	},
+	// A Service (Headless and Portless)
+	{
+		Qname: "hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20"),
+		},
+	},
+	// An Endpoint with no port
+	{
+		Qname: "172-0-0-20.hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("172-0-0-20.hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20"),
+		},
+	},
+	// An Endpoint ip
+	{
+		Qname: "172-0-0-2.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("172-0-0-2.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2"),
+		},
+	},
+	// A Endpoint ip
+	{
+		Qname: "172-0-0-3.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("172-0-0-3.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3"),
+		},
+	},
+	// An Endpoint by name
+	{
+		Qname: "dup-name.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
+			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
+		},
+	},
+	// SRV Service (Headless)
+	{
+		Qname: "_http._tcp.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 172-0-0-2.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 172-0-0-3.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 5678-abcd--1.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 5678-abcd--2.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 dup-name.hdls1.testns.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("172-0-0-2.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2"),
+			test.A("172-0-0-3.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3"),
+			test.AAAA("5678-abcd--1.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1"),
+			test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2"),
+			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
+			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
+		},
+	},
+	{ // An A record query for an existing headless service should return a record for each of its ipv4 endpoints
+		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2"),
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3"),
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
+			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
+		},
+	},
+	// SRV Service (Headless and portless)
+	{
+		Qname: "*.*.hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// AAAA
+	{
+		Qname: "5678-abcd--2.hdls1.testns.svc.cluster.local", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2")},
+	},
+	// CNAME External
+	{
+		Qname: "external.testns.svc.cluster.local.", Qtype: dns.TypeCNAME,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
+		},
+	},
+	// CNAME External To Internal Service
+	{
+		Qname: "external-to-service.testns.svc.cluster.local", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("external-to-service.testns.svc.cluster.local.	5	IN	CNAME	svc1.testns.svc.cluster.local."),
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	// AAAA Service (with an existing A record, but no AAAA record)
+	{
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// AAAA Service (non-existing service)
+	{
+		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// A Service (non-existing service)
+	{
+		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// A Service (non-existing namespace)
+	{
+		Qname: "svc0.svc-nons.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// TXT Schema
+	{
+		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.TXT("dns-version.cluster.local 28800 IN TXT 1.1.0"),
+		},
+	},
+	// A Service (Headless) does not exist
+	{
+		Qname: "bogusendpoint.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// A Service does not exist
+	{
+		Qname: "bogusendpoint.svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// AAAA Service
+	{
+		Qname: "svc6.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("svc6.testns.svc.cluster.local.	5	IN	AAAA	1234:abcd::1"),
+		},
+	},
+	// SRV
+	{
+		Qname: "_http._tcp.svc6.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc6.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc6.testns.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.AAAA("svc6.testns.svc.cluster.local.	5	IN	AAAA	1234:abcd::1"),
+		},
+	},
+	// AAAA Service (Headless)
+	{
+		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1"),
+			test.AAAA("hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2"),
+		},
+	},
+	// AAAA Endpoint
+	{
+		Qname: "5678-abcd--1.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("5678-abcd--1.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1"),
+		},
+	},
+
+	{
+		Qname: "svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (existing domain)
+	{
+		Qname: "svc.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (existing domain)
+	{
+		Qname: "testns.svc.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (non existing domain)
+	{
+		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (non existing domain)
+	{
+		Qname: "foo.svc.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+}
+
+func TestServeDNS(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	ctx := context.TODO()
+
+	for i, tc := range dnsTestCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		// Before sorting, make sure that CNAMES do not appear after their target records
+		if err := test.CNAMEOrder(resp); err != nil {
+			t.Error(err)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+var nsTestCases = []test.Case{
+	// A Service for an "exposed" namespace that "does exist"
+	{
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	// A service for an "exposed" namespace that "doesn't exist"
+	{
+		Qname: "svc1.nsnoexist.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1551484803 7200 1800 86400 30"),
+		},
+	},
+}
+
+func TestServeNamespaceDNS(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	// if no namespaces are explicitly exposed, then they are all implicitly exposed
+	k.Namespaces = map[string]struct{}{}
+	ctx := context.TODO()
+
+	for i, tc := range nsTestCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		// Before sorting, make sure that CNAMES do not appear after their target records
+		test.CNAMEOrder(resp)
+
+		test.SortAndCheck(resp, tc)
+	}
+}
+
+var notSyncedTestCases = []test.Case{
+	{
+		// We should get ServerFailure instead of NameError for missing records when we kubernetes hasn't synced
+		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeServerFailure,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+}
+
+func TestNotSyncedServeDNS(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{
+		notSynced: true,
+	}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	ctx := context.TODO()
+
+	for i, tc := range notSyncedTestCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		if err := test.CNAMEOrder(resp); err != nil {
+			t.Error(err)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+type APIConnServeTest struct {
+	notSynced bool
+}
+
+func (a APIConnServeTest) HasSynced() bool                         { return !a.notSynced }
+func (APIConnServeTest) Run()                                      {}
+func (APIConnServeTest) Stop() error                               { return nil }
+func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints { return nil }
+func (APIConnServeTest) SvcIndexReverse(string) []*object.Service  { return nil }
+func (APIConnServeTest) Modified() int64                           { return int64(3) }
+
+func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
+	if ip != "10.240.0.1" {
+		return []*object.Pod{}
+	}
+	a := []*object.Pod{
+		{Namespace: "podns", Name: "foo", PodIP: "10.240.0.1"}, // Remote IP set in test.ResponseWriter
+	}
+	return a
+}
+
+var svcIndex = map[string][]*object.Service{
+	"svc1.testns": {
+		{
+			Name:      "svc1",
+			Namespace: "testns",
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: "10.0.0.1",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"svcempty.testns": {
+		{
+			Name:      "svcempty",
+			Namespace: "testns",
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: "10.0.0.1",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"svc6.testns": {
+		{
+			Name:      "svc6",
+			Namespace: "testns",
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: "1234:abcd::1",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"hdls1.testns": {
+		{
+			Name:      "hdls1",
+			Namespace: "testns",
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: api.ClusterIPNone,
+		},
+	},
+	"external.testns": {
+		{
+			Name:         "external",
+			Namespace:    "testns",
+			ExternalName: "ext.interwebs.test",
+			Type:         api.ServiceTypeExternalName,
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"external-to-service.testns": {
+		{
+			Name:         "external-to-service",
+			Namespace:    "testns",
+			ExternalName: "svc1.testns.svc.cluster.local.",
+			Type:         api.ServiceTypeExternalName,
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"hdlsprtls.testns": {
+		{
+			Name:      "hdlsprtls",
+			Namespace: "testns",
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: api.ClusterIPNone,
+		},
+	},
+	"svc1.unexposedns": {
+		{
+			Name:      "svc1",
+			Namespace: "unexposedns",
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: "10.0.0.2",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+}
+
+func (APIConnServeTest) SvcIndex(s string) []*object.Service { return svcIndex[s] }
+
+func (APIConnServeTest) ServiceList() []*object.Service {
+	var svcs []*object.Service
+	for _, svc := range svcIndex {
+		svcs = append(svcs, svc...)
+	}
+	return svcs
+}
+
+var epsIndex = map[string][]*object.Endpoints{
+	"svc1.testns": {{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "172.0.0.1", Hostname: "ep1a"},
+				},
+				Ports: []object.EndpointPort{
+					{Port: 80, Protocol: "tcp", Name: "http"},
+				},
+			},
+		},
+		Name:      "svc1",
+		Namespace: "testns",
+	}},
+	"svcempty.testns": {{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: nil,
+				Ports: []object.EndpointPort{
+					{Port: 80, Protocol: "tcp", Name: "http"},
+				},
+			},
+		},
+		Name:      "svcempty",
+		Namespace: "testns",
+	}},
+	"hdls1.testns": {{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "172.0.0.2"},
+					{IP: "172.0.0.3"},
+					{IP: "172.0.0.4", Hostname: "dup-name"},
+					{IP: "172.0.0.5", Hostname: "dup-name"},
+					{IP: "5678:abcd::1"},
+					{IP: "5678:abcd::2"},
+				},
+				Ports: []object.EndpointPort{
+					{Port: 80, Protocol: "tcp", Name: "http"},
+				},
+			},
+		},
+		Name:      "hdls1",
+		Namespace: "testns",
+	}},
+	"hdlsprtls.testns": {{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "172.0.0.20"},
+				},
+				Ports: []object.EndpointPort{{Port: -1}},
+			},
+		},
+		Name:      "hdlsprtls",
+		Namespace: "testns",
+	}},
+}
+
+func (APIConnServeTest) EpIndex(s string) []*object.Endpoints {
+	return epsIndex[s]
+}
+
+func (APIConnServeTest) EndpointsList() []*object.Endpoints {
+	var eps []*object.Endpoints
+	for _, ep := range epsIndex {
+		eps = append(eps, ep...)
+	}
+	return eps
+}
+
+func (APIConnServeTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+	return &api.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "test.node.foo.bar",
+		},
+	}, nil
+}
+
+func (APIConnServeTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	if name == "pod-nons" { // handler_pod_verified_test.go uses this for non-existent namespace.
+		return &api.Namespace{}, nil
+	}
+	if name == "nsnoexist" {
+		return nil, fmt.Errorf("namespace not found")
+	}
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}

--- a/coredns/plugin/kubernetes/informer_test.go
+++ b/coredns/plugin/kubernetes/informer_test.go
@@ -1,0 +1,111 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+
+	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestDefaultProcessor(t *testing.T) {
+	pbuild := object.DefaultProcessor(object.ToService(true), nil)
+	reh := cache.ResourceEventHandlerFuncs{}
+	idx := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
+	processor := pbuild(idx, reh)
+	testProcessor(t, processor, idx)
+}
+
+func testProcessor(t *testing.T, processor cache.ProcessFunc, idx cache.Indexer) {
+	obj := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "service1", Namespace: "test1"},
+		Spec:       api.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []api.ServicePort{{Port: 80}}},
+	}
+	obj2 := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "service2", Namespace: "test1"},
+		Spec:       api.ServiceSpec{ClusterIP: "5.6.7.8", Ports: []api.ServicePort{{Port: 80}}},
+	}
+
+	// Add the objects
+	err := processor(cache.Deltas{
+		{Type: cache.Added, Object: obj},
+		{Type: cache.Added, Object: obj2},
+	})
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+	got, exists, err := idx.Get(obj)
+	if err != nil {
+		t.Fatalf("get added object failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("added object not found in index")
+	}
+	svc, ok := got.(*object.Service)
+	if !ok {
+		t.Fatal("object in index was incorrect type")
+	}
+	if svc.ClusterIP != obj.Spec.ClusterIP {
+		t.Fatalf("expected %v, got %v", obj.Spec.ClusterIP, svc.ClusterIP)
+	}
+
+	// Update an object
+	obj.Spec.ClusterIP = "1.2.3.5"
+	err = processor(cache.Deltas{{
+		Type:   cache.Updated,
+		Object: obj,
+	}})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	got, exists, err = idx.Get(obj)
+	if err != nil {
+		t.Fatalf("get updated object failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("updated object not found in index")
+	}
+	svc, ok = got.(*object.Service)
+	if !ok {
+		t.Fatal("object in index was incorrect type")
+	}
+	if svc.ClusterIP != obj.Spec.ClusterIP {
+		t.Fatalf("expected %v, got %v", obj.Spec.ClusterIP, svc.ClusterIP)
+	}
+
+	// Delete an object
+	err = processor(cache.Deltas{{
+		Type:   cache.Deleted,
+		Object: obj2,
+	}})
+	if err != nil {
+		t.Fatalf("delete test failed: %v", err)
+	}
+	_, exists, err = idx.Get(obj2)
+	if err != nil {
+		t.Fatalf("get deleted object failed: %v", err)
+	}
+	if exists {
+		t.Fatal("deleted object found in index")
+	}
+
+	// Delete an object via tombstone
+	key, _ := cache.MetaNamespaceKeyFunc(obj)
+	tombstone := cache.DeletedFinalStateUnknown{Key: key, Obj: svc}
+	err = processor(cache.Deltas{{
+		Type:   cache.Deleted,
+		Object: tombstone,
+	}})
+	if err != nil {
+		t.Fatalf("tombstone delete test failed: %v", err)
+	}
+	_, exists, err = idx.Get(svc)
+	if err != nil {
+		t.Fatalf("get tombstone deleted object failed: %v", err)
+	}
+	if exists {
+		t.Fatal("tombstone deleted object found in index")
+	}
+}

--- a/coredns/plugin/kubernetes/kubernetes.go
+++ b/coredns/plugin/kubernetes/kubernetes.go
@@ -1,0 +1,519 @@
+// Package kubernetes provides the kubernetes backend.
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/coredns/coredns/plugin/pkg/fall"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Kubernetes implements a plugin that connects to a Kubernetes cluster.
+type Kubernetes struct {
+	Next             plugin.Handler
+	Zones            []string
+	Upstream         *upstream.Upstream
+	APIServerList    []string
+	APICertAuth      string
+	APIClientCert    string
+	APIClientKey     string
+	ClientConfig     clientcmd.ClientConfig
+	APIConn          dnsController
+	Namespaces       map[string]struct{}
+	podMode          string
+	endpointNameMode bool
+	Fall             fall.F
+	ttl              uint32
+	opts             dnsControlOpts
+	primaryZoneIndex int
+	localIPs         []net.IP
+	autoPathSearch   []string // Local search path from /etc/resolv.conf. Needed for autopath.
+}
+
+// New returns a initialized Kubernetes. It default interfaceAddrFunc to return 127.0.0.1. All other
+// values default to their zero value, primaryZoneIndex will thus point to the first zone.
+func New(zones []string) *Kubernetes {
+	k := new(Kubernetes)
+	k.Zones = zones
+	k.Namespaces = make(map[string]struct{})
+	k.podMode = podModeDisabled
+	k.ttl = defaultTTL
+
+	return k
+}
+
+const (
+	// podModeDisabled is the default value where pod requests are ignored
+	podModeDisabled = "disabled"
+	// podModeVerified is where Pod requests are answered only if they exist
+	podModeVerified = "verified"
+	// podModeInsecure is where pod requests are answered without verifying they exist
+	podModeInsecure = "insecure"
+	// DNSSchemaVersion is the schema version: https://github.com/kubernetes/dns/blob/master/docs/specification.md
+	DNSSchemaVersion = "1.1.0"
+	// Svc is the DNS schema for kubernetes services
+	Svc = "svc"
+	// Pod is the DNS schema for kubernetes pods
+	Pod = "pod"
+	// defaultTTL to apply to all answers.
+	defaultTTL = 5
+)
+
+var (
+	errNoItems        = errors.New("no items found")
+	errNsNotExposed   = errors.New("namespace is not exposed")
+	errInvalidRequest = errors.New("invalid query name")
+)
+
+// Services implements the ServiceBackend interface.
+func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (svcs []msg.Service, err error) {
+	// We're looking again at types, which we've already done in ServeDNS, but there are some types k8s just can't answer.
+	switch state.QType() {
+
+	case dns.TypeTXT:
+		// 1 label + zone, label must be "dns-version".
+		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
+
+		segs := dns.SplitDomainName(t)
+		if len(segs) != 1 {
+			return nil, nil
+		}
+		if segs[0] != "dns-version" {
+			return nil, nil
+		}
+		svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
+		return []msg.Service{svc}, nil
+
+	case dns.TypeNS:
+		// We can only get here if the qname equals the zone, see ServeDNS in handler.go.
+		nss := k.nsAddrs(false, state.Zone)
+		var svcs []msg.Service
+		for _, ns := range nss {
+			if ns.Header().Rrtype == dns.TypeA {
+				svcs = append(svcs, msg.Service{Host: ns.(*dns.A).A.String(), Key: msg.Path(ns.Header().Name, coredns), TTL: k.ttl})
+				continue
+			}
+			if ns.Header().Rrtype == dns.TypeAAAA {
+				svcs = append(svcs, msg.Service{Host: ns.(*dns.AAAA).AAAA.String(), Key: msg.Path(ns.Header().Name, coredns), TTL: k.ttl})
+			}
+		}
+		return svcs, nil
+	}
+
+	if isDefaultNS(state.Name(), state.Zone) {
+		nss := k.nsAddrs(false, state.Zone)
+		var svcs []msg.Service
+		for _, ns := range nss {
+			if ns.Header().Rrtype == dns.TypeA && state.QType() == dns.TypeA {
+				svcs = append(svcs, msg.Service{Host: ns.(*dns.A).A.String(), Key: msg.Path(state.QName(), coredns), TTL: k.ttl})
+				continue
+			}
+			if ns.Header().Rrtype == dns.TypeAAAA && state.QType() == dns.TypeAAAA {
+				svcs = append(svcs, msg.Service{Host: ns.(*dns.AAAA).AAAA.String(), Key: msg.Path(state.QName(), coredns), TTL: k.ttl})
+			}
+		}
+		return svcs, nil
+	}
+
+	s, e := k.Records(ctx, state, false)
+
+	// SRV for external services is not yet implemented, so remove those records.
+
+	if state.QType() != dns.TypeSRV {
+		return s, e
+	}
+
+	internal := []msg.Service{}
+	for _, svc := range s {
+		if t, _ := svc.HostType(); t != dns.TypeCNAME {
+			internal = append(internal, svc)
+		}
+	}
+
+	return internal, e
+}
+
+// primaryZone will return the first non-reverse zone being handled by this plugin
+func (k *Kubernetes) primaryZone() string { return k.Zones[k.primaryZoneIndex] }
+
+// Lookup implements the ServiceBackend interface.
+func (k *Kubernetes) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	return k.Upstream.Lookup(ctx, state, name, typ)
+}
+
+// IsNameError implements the ServiceBackend interface.
+func (k *Kubernetes) IsNameError(err error) bool {
+	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest
+}
+
+func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
+	if k.ClientConfig != nil {
+		return k.ClientConfig.ClientConfig()
+	}
+	loadingRules := &clientcmd.ClientConfigLoadingRules{}
+	overrides := &clientcmd.ConfigOverrides{}
+	clusterinfo := clientcmdapi.Cluster{}
+	authinfo := clientcmdapi.AuthInfo{}
+
+	// Connect to API from in cluster
+	if len(k.APIServerList) == 0 {
+		cc, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		cc.ContentType = "application/vnd.kubernetes.protobuf"
+		return cc, err
+	}
+
+	// Connect to API from out of cluster
+	// Only the first one is used. We will deprecate multiple endpoints later.
+	clusterinfo.Server = k.APIServerList[0]
+
+	if len(k.APICertAuth) > 0 {
+		clusterinfo.CertificateAuthority = k.APICertAuth
+	}
+	if len(k.APIClientCert) > 0 {
+		authinfo.ClientCertificate = k.APIClientCert
+	}
+	if len(k.APIClientKey) > 0 {
+		authinfo.ClientKey = k.APIClientKey
+	}
+
+	overrides.ClusterInfo = clusterinfo
+	overrides.AuthInfo = authinfo
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+
+	cc, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	cc.ContentType = "application/vnd.kubernetes.protobuf"
+	return cc, err
+
+}
+
+// InitKubeCache initializes a new Kubernetes cache.
+func (k *Kubernetes) InitKubeCache(ctx context.Context) (err error) {
+	config, err := k.getClientConfig()
+	if err != nil {
+		return err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes notification controller: %q", err)
+	}
+
+	if k.opts.labelSelector != nil {
+		var selector labels.Selector
+		selector, err = meta.LabelSelectorAsSelector(k.opts.labelSelector)
+		if err != nil {
+			return fmt.Errorf("unable to create Selector for LabelSelector '%s': %q", k.opts.labelSelector, err)
+		}
+		k.opts.selector = selector
+	}
+
+	if k.opts.namespaceLabelSelector != nil {
+		var selector labels.Selector
+		selector, err = meta.LabelSelectorAsSelector(k.opts.namespaceLabelSelector)
+		if err != nil {
+			return fmt.Errorf("unable to create Selector for LabelSelector '%s': %q", k.opts.namespaceLabelSelector, err)
+		}
+		k.opts.namespaceSelector = selector
+	}
+
+	k.opts.initPodCache = k.podMode == podModeVerified
+
+	k.opts.zones = k.Zones
+	k.opts.endpointNameMode = k.endpointNameMode
+	k.APIConn = newdnsController(ctx, kubeClient, k.opts)
+
+	return err
+}
+
+// Records looks up services in kubernetes.
+func (k *Kubernetes) Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error) {
+	r, e := parseRequest(state.Name(), state.Zone)
+	if e != nil {
+		return nil, e
+	}
+	if r.podOrSvc == "" {
+		return nil, nil
+	}
+
+	if dnsutil.IsReverse(state.Name()) > 0 {
+		return nil, errNoItems
+	}
+
+	if !wildcard(r.namespace) && !k.namespaceExposed(r.namespace) {
+		return nil, errNsNotExposed
+	}
+
+	if r.podOrSvc == Pod {
+		pods, err := k.findPods(r, state.Zone)
+		return pods, err
+	}
+
+	services, err := k.findServices(r, state.Zone)
+	return services, err
+}
+
+func endpointHostname(addr object.EndpointAddress, endpointNameMode bool) string {
+	if addr.Hostname != "" {
+		return addr.Hostname
+	}
+	if endpointNameMode && addr.TargetRefName != "" {
+		return addr.TargetRefName
+	}
+	if strings.Contains(addr.IP, ".") {
+		return strings.Replace(addr.IP, ".", "-", -1)
+	}
+	if strings.Contains(addr.IP, ":") {
+		return strings.Replace(addr.IP, ":", "-", -1)
+	}
+	return ""
+}
+
+func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service, err error) {
+	if k.podMode == podModeDisabled {
+		return nil, errNoItems
+	}
+
+	namespace := r.namespace
+	if !wildcard(namespace) && !k.namespaceExposed(namespace) {
+		return nil, errNoItems
+	}
+
+	podname := r.service
+
+	// handle empty pod name
+	if podname == "" {
+		if k.namespaceExposed(namespace) || wildcard(namespace) {
+			// NODATA
+			return nil, nil
+		}
+		// NXDOMAIN
+		return nil, errNoItems
+	}
+
+	zonePath := msg.Path(zone, coredns)
+	ip := ""
+	if strings.Count(podname, "-") == 3 && !strings.Contains(podname, "--") {
+		ip = strings.Replace(podname, "-", ".", -1)
+	} else {
+		ip = strings.Replace(podname, "-", ":", -1)
+	}
+
+	if k.podMode == podModeInsecure {
+		if !wildcard(namespace) && !k.namespaceExposed(namespace) { // no wildcard, but namespace does not exist
+			return nil, errNoItems
+		}
+
+		// If ip does not parse as an IP address, we return an error, otherwise we assume a CNAME and will try to resolve it in backend_lookup.go
+		if net.ParseIP(ip) == nil {
+			return nil, errNoItems
+		}
+
+		return []msg.Service{{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip, TTL: k.ttl}}, err
+	}
+
+	// PodModeVerified
+	err = errNoItems
+	if wildcard(podname) && !wildcard(namespace) {
+		// If namespace exists, err should be nil, so that we return NODATA instead of NXDOMAIN
+		if k.namespaceExposed(namespace) {
+			err = nil
+		}
+	}
+
+	for _, p := range k.APIConn.PodIndex(ip) {
+		// If namespace has a wildcard, filter results against Corefile namespace list.
+		if wildcard(namespace) && !k.namespaceExposed(p.Namespace) {
+			continue
+		}
+
+		// check for matching ip and namespace
+		if ip == p.PodIP && match(namespace, p.Namespace) {
+			s := msg.Service{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip, TTL: k.ttl}
+			pods = append(pods, s)
+
+			err = nil
+		}
+	}
+	return pods, err
+}
+
+// findServices returns the services matching r from the cache.
+func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.Service, err error) {
+	if !wildcard(r.namespace) && !k.namespaceExposed(r.namespace) {
+		return nil, errNoItems
+	}
+
+	// handle empty service name
+	if r.service == "" {
+		if k.namespaceExposed(r.namespace) || wildcard(r.namespace) {
+			// NODATA
+			return nil, nil
+		}
+		// NXDOMAIN
+		return nil, errNoItems
+	}
+
+	err = errNoItems
+	if wildcard(r.service) && !wildcard(r.namespace) {
+		// If namespace exists, err should be nil, so that we return NODATA instead of NXDOMAIN
+		if k.namespaceExposed(r.namespace) {
+			err = nil
+		}
+	}
+
+	var (
+		endpointsListFunc func() []*object.Endpoints
+		endpointsList     []*object.Endpoints
+		serviceList       []*object.Service
+	)
+
+	if wildcard(r.service) || wildcard(r.namespace) {
+		serviceList = k.APIConn.ServiceList()
+		endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EndpointsList() }
+	} else {
+		idx := object.ServiceKey(r.service, r.namespace)
+		serviceList = k.APIConn.SvcIndex(idx)
+		endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EpIndex(idx) }
+	}
+
+	zonePath := msg.Path(zone, coredns)
+	for _, svc := range serviceList {
+		if !(match(r.namespace, svc.Namespace) && match(r.service, svc.Name)) {
+			continue
+		}
+
+		// If request namespace is a wildcard, filter results against Corefile namespace list.
+		// (Namespaces without a wildcard were filtered before the call to this function.)
+		if wildcard(r.namespace) && !k.namespaceExposed(svc.Namespace) {
+			continue
+		}
+
+		// If "ignore empty_service" option is set and no endpoints exist, return NXDOMAIN unless
+		// it's a headless or externalName service (covered below).
+		if k.opts.ignoreEmptyService && svc.ClusterIP != api.ClusterIPNone && svc.Type != api.ServiceTypeExternalName {
+			// serve NXDOMAIN if no endpoint is able to answer
+			podsCount := 0
+			for _, ep := range endpointsListFunc() {
+				for _, eps := range ep.Subsets {
+					podsCount = podsCount + len(eps.Addresses)
+				}
+			}
+
+			if podsCount == 0 {
+				continue
+			}
+		}
+
+		// Endpoint query or headless service
+		if svc.ClusterIP == api.ClusterIPNone || r.endpoint != "" {
+			if endpointsList == nil {
+				endpointsList = endpointsListFunc()
+			}
+			for _, ep := range endpointsList {
+				if ep.Name != svc.Name || ep.Namespace != svc.Namespace {
+					continue
+				}
+
+				for _, eps := range ep.Subsets {
+					for _, addr := range eps.Addresses {
+
+						// See comments in parse.go parseRequest about the endpoint handling.
+						if r.endpoint != "" {
+							if !match(r.endpoint, endpointHostname(addr, k.endpointNameMode)) {
+								continue
+							}
+						}
+
+						for _, p := range eps.Ports {
+							if !(match(r.port, p.Name) && match(r.protocol, string(p.Protocol))) {
+								continue
+							}
+							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
+							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, endpointHostname(addr, k.endpointNameMode)}, "/")
+
+							err = nil
+
+							services = append(services, s)
+						}
+					}
+				}
+			}
+			continue
+		}
+
+		// External service
+		if svc.Type == api.ServiceTypeExternalName {
+			s := msg.Service{Key: strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/"), Host: svc.ExternalName, TTL: k.ttl}
+			if t, _ := s.HostType(); t == dns.TypeCNAME {
+				s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
+				services = append(services, s)
+
+				err = nil
+			}
+			continue
+		}
+
+		// ClusterIP service
+		for _, p := range svc.Ports {
+			if !(match(r.port, p.Name) && match(r.protocol, string(p.Protocol))) {
+				continue
+			}
+
+			err = nil
+
+			s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.ttl}
+			s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
+
+			services = append(services, s)
+		}
+	}
+	return services, err
+}
+
+// Serial return the SOA serial.
+func (k *Kubernetes) Serial(state request.Request) uint32 { return uint32(k.APIConn.Modified()) }
+
+// MinTTL returns the minimal TTL.
+func (k *Kubernetes) MinTTL(state request.Request) uint32 { return k.ttl }
+
+// match checks if a and b are equal taking wildcards into account.
+func match(a, b string) bool {
+	if wildcard(a) {
+		return true
+	}
+	if wildcard(b) {
+		return true
+	}
+	return strings.EqualFold(a, b)
+}
+
+// wildcard checks whether s contains a wildcard value defined as "*" or "any".
+func wildcard(s string) bool {
+	return s == "*" || s == "any"
+}
+
+const coredns = "c" // used as a fake key prefix in msg.Service

--- a/coredns/plugin/kubernetes/kubernetes_apex_test.go
+++ b/coredns/plugin/kubernetes/kubernetes_apex_test.go
@@ -1,0 +1,93 @@
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var kubeApexCases = []test.Case{
+	{
+		Qname: "cluster.local.", Qtype: dns.TypeSOA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "cluster.local.", Qtype: dns.TypeHINFO,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.NS("cluster.local. 5     IN      NS     ns.dns.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("ns.dns.cluster.local.   5       IN      A       127.0.0.1"),
+		},
+	},
+	{
+		Qname: "cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	{
+		Qname: "cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+}
+
+func TestServeDNSApex(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.localIPs = []net.IP{net.ParseIP("127.0.0.1")}
+	ctx := context.TODO()
+
+	for i, tc := range kubeApexCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d, expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error ford", i)
+		}
+
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Errorf("Test %d: %v", i, err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/kubernetes_test.go
+++ b/coredns/plugin/kubernetes/kubernetes_test.go
@@ -1,0 +1,367 @@
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWildcard(t *testing.T) {
+	var tests = []struct {
+		s        string
+		expected bool
+	}{
+		{"mynamespace", false},
+		{"*", true},
+		{"any", true},
+		{"my*space", false},
+		{"*space", false},
+		{"myname*", false},
+	}
+
+	for _, te := range tests {
+		got := wildcard(te.s)
+		if got != te.expected {
+			t.Errorf("Expected Wildcard result '%v' for example '%v', got '%v'.", te.expected, te.s, got)
+		}
+	}
+}
+
+func TestEndpointHostname(t *testing.T) {
+	var tests = []struct {
+		ip               string
+		hostname         string
+		expected         string
+		podName          string
+		endpointNameMode bool
+	}{
+		{"10.11.12.13", "", "10-11-12-13", "", false},
+		{"10.11.12.13", "epname", "epname", "", false},
+		{"10.11.12.13", "", "10-11-12-13", "hello-abcde", false},
+		{"10.11.12.13", "epname", "epname", "hello-abcde", false},
+		{"10.11.12.13", "epname", "epname", "hello-abcde", true},
+		{"10.11.12.13", "", "hello-abcde", "hello-abcde", true},
+	}
+	for _, test := range tests {
+		result := endpointHostname(object.EndpointAddress{IP: test.ip, Hostname: test.hostname, TargetRefName: test.podName}, test.endpointNameMode)
+		if result != test.expected {
+			t.Errorf("Expected endpoint name for (ip:%v hostname:%v) to be '%v', but got '%v'", test.ip, test.hostname, test.expected, result)
+		}
+	}
+}
+
+type APIConnServiceTest struct{}
+
+func (APIConnServiceTest) HasSynced() bool                           { return true }
+func (APIConnServiceTest) Run()                                      {}
+func (APIConnServiceTest) Stop() error                               { return nil }
+func (APIConnServiceTest) PodIndex(string) []*object.Pod             { return nil }
+func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service  { return nil }
+func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints { return nil }
+func (APIConnServiceTest) Modified() int64                           { return 0 }
+
+func (APIConnServiceTest) SvcIndex(string) []*object.Service {
+	svcs := []*object.Service{
+		{
+			Name:      "svc1",
+			Namespace: "testns",
+			ClusterIP: "10.0.0.1",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+		{
+			Name:      "hdls1",
+			Namespace: "testns",
+			ClusterIP: api.ClusterIPNone,
+		},
+		{
+			Name:         "external",
+			Namespace:    "testns",
+			ExternalName: "coredns.io",
+			Type:         api.ServiceTypeExternalName,
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	}
+	return svcs
+}
+
+func (APIConnServiceTest) ServiceList() []*object.Service {
+	svcs := []*object.Service{
+		{
+			Name:      "svc1",
+			Namespace: "testns",
+			ClusterIP: "10.0.0.1",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+		{
+			Name:      "hdls1",
+			Namespace: "testns",
+			ClusterIP: api.ClusterIPNone,
+		},
+		{
+			Name:         "external",
+			Namespace:    "testns",
+			ExternalName: "coredns.io",
+			Type:         api.ServiceTypeExternalName,
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	}
+	return svcs
+}
+
+func (APIConnServiceTest) EpIndex(string) []*object.Endpoints {
+	eps := []*object.Endpoints{
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "172.0.0.1", Hostname: "ep1a"},
+					},
+					Ports: []object.EndpointPort{
+						{Port: 80, Protocol: "tcp", Name: "http"},
+					},
+				},
+			},
+			Name:      "svc1",
+			Namespace: "testns",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "172.0.0.2"},
+					},
+					Ports: []object.EndpointPort{
+						{Port: 80, Protocol: "tcp", Name: "http"},
+					},
+				},
+			},
+			Name:      "hdls1",
+			Namespace: "testns",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "172.0.0.3"},
+					},
+					Ports: []object.EndpointPort{
+						{Port: 80, Protocol: "tcp", Name: "http"},
+					},
+				},
+			},
+			Name:      "hdls1",
+			Namespace: "testns",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "10.9.8.7", NodeName: "test.node.foo.bar"},
+					},
+				},
+			},
+		},
+	}
+	return eps
+}
+
+func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
+	eps := []*object.Endpoints{
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "172.0.0.1", Hostname: "ep1a"},
+					},
+					Ports: []object.EndpointPort{
+						{Port: 80, Protocol: "tcp", Name: "http"},
+					},
+				},
+			},
+			Name:      "svc1",
+			Namespace: "testns",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "172.0.0.2"},
+					},
+					Ports: []object.EndpointPort{
+						{Port: 80, Protocol: "tcp", Name: "http"},
+					},
+				},
+			},
+			Name:      "hdls1",
+			Namespace: "testns",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "172.0.0.3"},
+					},
+					Ports: []object.EndpointPort{
+						{Port: 80, Protocol: "tcp", Name: "http"},
+					},
+				},
+			},
+			Name:      "hdls1",
+			Namespace: "testns",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{IP: "10.9.8.7", NodeName: "test.node.foo.bar"},
+					},
+				},
+			},
+		},
+	}
+	return eps
+}
+
+func (APIConnServiceTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+	return &api.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "test.node.foo.bar",
+		},
+	}, nil
+}
+
+func (APIConnServiceTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}
+
+func TestServices(t *testing.T) {
+	k := New([]string{"interwebs.test."})
+	k.APIConn = &APIConnServiceTest{}
+
+	type svcAns struct {
+		host string
+		key  string
+	}
+	type svcTest struct {
+		qname  string
+		qtype  uint16
+		answer svcAns
+	}
+	tests := []svcTest{
+		// Cluster IP Services
+		{qname: "svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "10.0.0.1", key: "/" + coredns + "/test/interwebs/svc/testns/svc1"}},
+		{qname: "_http._tcp.svc1.testns.svc.interwebs.test.", qtype: dns.TypeSRV, answer: svcAns{host: "10.0.0.1", key: "/" + coredns + "/test/interwebs/svc/testns/svc1"}},
+		{qname: "ep1a.svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "172.0.0.1", key: "/" + coredns + "/test/interwebs/svc/testns/svc1/ep1a"}},
+
+		// External Services
+		{qname: "external.testns.svc.interwebs.test.", qtype: dns.TypeCNAME, answer: svcAns{host: "coredns.io", key: "/" + coredns + "/test/interwebs/svc/testns/external"}},
+	}
+
+	for i, test := range tests {
+		state := request.Request{
+			Req:  &dns.Msg{Question: []dns.Question{{Name: test.qname, Qtype: test.qtype}}},
+			Zone: "interwebs.test.", // must match from k.Zones[0]
+		}
+		svcs, e := k.Services(context.TODO(), state, false, plugin.Options{})
+		if e != nil {
+			t.Errorf("Test %d: got error '%v'", i, e)
+			continue
+		}
+		if len(svcs) != 1 {
+			t.Errorf("Test %d, expected 1 answer, got %v", i, len(svcs))
+			continue
+		}
+
+		if test.answer.host != svcs[0].Host {
+			t.Errorf("Test %d, expected host '%v', got '%v'", i, test.answer.host, svcs[0].Host)
+		}
+		if test.answer.key != svcs[0].Key {
+			t.Errorf("Test %d, expected key '%v', got '%v'", i, test.answer.key, svcs[0].Key)
+		}
+	}
+}
+
+func TestServicesAuthority(t *testing.T) {
+	k := New([]string{"interwebs.test."})
+	k.APIConn = &APIConnServiceTest{}
+
+	type svcAns struct {
+		host string
+		key  string
+	}
+	type svcTest struct {
+		localIPs []net.IP
+		qname    string
+		qtype    uint16
+		answer   []svcAns
+	}
+	tests := []svcTest{
+		{localIPs: []net.IP{net.ParseIP("1.2.3.4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: []svcAns{{host: "1.2.3.4", key: "/" + coredns + "/test/interwebs/dns/ns"}}},
+		{localIPs: []net.IP{net.ParseIP("1.2.3.4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
+		{localIPs: []net.IP{net.ParseIP("1:2::3:4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
+		{localIPs: []net.IP{net.ParseIP("1:2::3:4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: []svcAns{{host: "1:2::3:4", key: "/" + coredns + "/test/interwebs/dns/ns"}}},
+		{
+			localIPs: []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1:2::3:4")},
+			qname:    "ns.dns.interwebs.test.",
+			qtype:    dns.TypeNS, answer: []svcAns{
+				{host: "1.2.3.4", key: "/" + coredns + "/test/interwebs/dns/ns"},
+				{host: "1:2::3:4", key: "/" + coredns + "/test/interwebs/dns/ns"},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		k.localIPs = test.localIPs
+
+		state := request.Request{
+			Req:  &dns.Msg{Question: []dns.Question{{Name: test.qname, Qtype: test.qtype}}},
+			Zone: k.Zones[0],
+		}
+		svcs, e := k.Services(context.TODO(), state, false, plugin.Options{})
+		if e != nil {
+			t.Errorf("Test %d: got error '%v'", i, e)
+			continue
+		}
+		if test.answer != nil && len(svcs) != len(test.answer) {
+			t.Errorf("Test %d, expected 1 answer, got %v", i, len(svcs))
+			continue
+		}
+		if test.answer == nil && len(svcs) != 0 {
+			t.Errorf("Test %d, expected no answer, got %v", i, len(svcs))
+			continue
+		}
+
+		if test.answer == nil && len(svcs) == 0 {
+			continue
+		}
+
+		for i, answer := range test.answer {
+			if answer.host != svcs[i].Host {
+				t.Errorf("Test %d, expected host '%v', got '%v'", i, answer.host, svcs[i].Host)
+			}
+			if answer.key != svcs[i].Key {
+				t.Errorf("Test %d, expected key '%v', got '%v'", i, answer.key, svcs[i].Key)
+			}
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/local.go
+++ b/coredns/plugin/kubernetes/local.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import (
+	"net"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+)
+
+// boundIPs returns the list of non-loopback IPs that CoreDNS is bound to
+func boundIPs(c *caddy.Controller) (ips []net.IP) {
+	conf := dnsserver.GetConfig(c)
+	hosts := conf.ListenHosts
+	if hosts == nil || hosts[0] == "" {
+		hosts = nil
+		addrs, err := net.InterfaceAddrs()
+		if err != nil {
+			return nil
+		}
+		for _, addr := range addrs {
+			hosts = append(hosts, addr.String())
+		}
+	}
+	for _, host := range hosts {
+		ip, _, _ := net.ParseCIDR(host)
+		ip4 := ip.To4()
+		if ip4 != nil && !ip4.IsLoopback() {
+			ips = append(ips, ip4)
+			continue
+		}
+		ip6 := ip.To16()
+		if ip6 != nil && !ip6.IsLoopback() {
+			ips = append(ips, ip6)
+		}
+	}
+	return ips
+}

--- a/coredns/plugin/kubernetes/log_test.go
+++ b/coredns/plugin/kubernetes/log_test.go
@@ -1,0 +1,5 @@
+package kubernetes
+
+import clog "github.com/coredns/coredns/plugin/pkg/log"
+
+func init() { clog.Discard() }

--- a/coredns/plugin/kubernetes/metadata.go
+++ b/coredns/plugin/kubernetes/metadata.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/coredns/coredns/request"
+)
+
+// Metadata implements the metadata.Provider interface.
+func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) context.Context {
+	pod := k.podWithIP(state.IP())
+	if pod != nil {
+		metadata.SetValueFunc(ctx, "kubernetes/client-namespace", func() string {
+			return pod.Namespace
+		})
+
+		metadata.SetValueFunc(ctx, "kubernetes/client-pod-name", func() string {
+			return pod.Name
+		})
+	}
+
+	zone := plugin.Zones(k.Zones).Matches(state.Name())
+	if zone == "" {
+		return ctx
+	}
+	// possible optimization: cache r so it doesn't need to be calculated again in ServeDNS
+	r, err := parseRequest(state.Name(), zone)
+	if err != nil {
+		metadata.SetValueFunc(ctx, "kubernetes/parse-error", func() string {
+			return err.Error()
+		})
+		return ctx
+	}
+
+	metadata.SetValueFunc(ctx, "kubernetes/port-name", func() string {
+		return r.port
+	})
+
+	metadata.SetValueFunc(ctx, "kubernetes/protocol", func() string {
+		return r.protocol
+	})
+
+	metadata.SetValueFunc(ctx, "kubernetes/endpoint", func() string {
+		return r.endpoint
+	})
+
+	metadata.SetValueFunc(ctx, "kubernetes/service", func() string {
+		return r.service
+	})
+
+	metadata.SetValueFunc(ctx, "kubernetes/namespace", func() string {
+		return r.namespace
+	})
+
+	metadata.SetValueFunc(ctx, "kubernetes/kind", func() string {
+		return r.podOrSvc
+	})
+
+	return ctx
+}

--- a/coredns/plugin/kubernetes/metadata_test.go
+++ b/coredns/plugin/kubernetes/metadata_test.go
@@ -1,0 +1,155 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+var metadataCases = []struct {
+	Qname    string
+	Qtype    uint16
+	RemoteIP string
+	Md       map[string]string
+}{
+	{
+		Qname: "foo.bar.notapod.cluster.local.", Qtype: dns.TypeA,
+		Md: map[string]string{
+			"kubernetes/parse-error": "invalid query name",
+		},
+	},
+	{
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Md: map[string]string{
+			"kubernetes/endpoint":  "",
+			"kubernetes/kind":      "pod",
+			"kubernetes/namespace": "podns",
+			"kubernetes/port-name": "*",
+			"kubernetes/protocol":  "*",
+			"kubernetes/service":   "10-240-0-1",
+		},
+	},
+	{
+		Qname: "s.ns.svc.cluster.local.", Qtype: dns.TypeA,
+		Md: map[string]string{
+			"kubernetes/endpoint":  "",
+			"kubernetes/kind":      "svc",
+			"kubernetes/namespace": "ns",
+			"kubernetes/port-name": "*",
+			"kubernetes/protocol":  "*",
+			"kubernetes/service":   "s",
+		},
+	},
+	{
+		Qname: "s.ns.svc.cluster.local.", Qtype: dns.TypeA,
+		RemoteIP: "10.10.10.10",
+		Md: map[string]string{
+			"kubernetes/endpoint":  "",
+			"kubernetes/kind":      "svc",
+			"kubernetes/namespace": "ns",
+			"kubernetes/port-name": "*",
+			"kubernetes/protocol":  "*",
+			"kubernetes/service":   "s",
+		},
+	},
+	{
+		Qname: "_http._tcp.s.ns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		RemoteIP: "10.10.10.10",
+		Md: map[string]string{
+			"kubernetes/endpoint":  "",
+			"kubernetes/kind":      "svc",
+			"kubernetes/namespace": "ns",
+			"kubernetes/port-name": "http",
+			"kubernetes/protocol":  "tcp",
+			"kubernetes/service":   "s",
+		},
+	},
+	{
+		Qname: "ep.s.ns.svc.cluster.local.", Qtype: dns.TypeA,
+		RemoteIP: "10.10.10.10",
+		Md: map[string]string{
+			"kubernetes/endpoint":  "ep",
+			"kubernetes/kind":      "svc",
+			"kubernetes/namespace": "ns",
+			"kubernetes/port-name": "*",
+			"kubernetes/protocol":  "*",
+			"kubernetes/service":   "s",
+		},
+	},
+	{
+		Qname: "example.com.", Qtype: dns.TypeA,
+		RemoteIP: "10.10.10.10",
+		Md:       map[string]string{},
+	},
+}
+
+func mapsDiffer(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return true
+	}
+
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || va != vb {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMetadata(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+
+	for i, tc := range metadataCases {
+		ctx := metadata.ContextWithMetadata(context.Background())
+		state := request.Request{
+			Req:  &dns.Msg{Question: []dns.Question{{Name: tc.Qname, Qtype: tc.Qtype}}},
+			Zone: ".",
+			W:    &test.ResponseWriter{RemoteIP: tc.RemoteIP},
+		}
+
+		k.Metadata(ctx, state)
+
+		md := make(map[string]string)
+		for _, l := range metadata.Labels(ctx) {
+			md[l] = metadata.ValueFunc(ctx, l)()
+		}
+		if mapsDiffer(tc.Md, md) {
+			t.Errorf("Case %d expected metadata %v and got %v", i, tc.Md, md)
+		}
+	}
+}
+
+func TestMetadataPodsVerified(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.podMode = podModeVerified
+	k.APIConn = &APIConnServeTest{}
+
+	ctx := metadata.ContextWithMetadata(context.Background())
+	state := request.Request{
+		Req:  &dns.Msg{Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA}}},
+		Zone: ".",
+		W:    &test.ResponseWriter{},
+	}
+
+	k.Metadata(ctx, state)
+
+	expect := map[string]string{
+		"kubernetes/client-namespace": "podns",
+		"kubernetes/client-pod-name":  "foo",
+	}
+
+	md := make(map[string]string)
+	for _, l := range metadata.Labels(ctx) {
+		md[l] = metadata.ValueFunc(ctx, l)()
+	}
+	if mapsDiffer(expect, md) {
+		t.Errorf("Expected metadata %v and got %v", expect, md)
+	}
+}

--- a/coredns/plugin/kubernetes/metrics.go
+++ b/coredns/plugin/kubernetes/metrics.go
@@ -1,0 +1,73 @@
+package kubernetes
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	api "k8s.io/api/core/v1"
+)
+
+var (
+	// DnsProgrammingLatency is defined as the time it took to program a DNS instance - from the time
+	// a service or pod has changed to the time the change was propagated and was available to be
+	// served by a DNS server.
+	// The definition of this SLI can be found at https://github.com/kubernetes/community/blob/master/sig-scalability/slos/dns_programming_latency.md
+	// Note that the metrics is partially based on the time exported by the endpoints controller on
+	// the master machine. The measurement may be inaccurate if there is a clock drift between the
+	// node and master machine.
+	// The service_kind label can be one of:
+	//   * cluster_ip
+	//   * headless_with_selector
+	//   * headless_without_selector
+	DnsProgrammingLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "dns_programming_duration_seconds",
+		// From 1 millisecond to ~17 minutes.
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 20),
+		Help:    "Histogram of the time (in seconds) it took to program a dns instance.",
+	}, []string{"service_kind"})
+
+	// durationSinceFunc returns the duration elapsed since the given time.
+	// Added as a global variable to allow injection for testing.
+	durationSinceFunc = time.Since
+)
+
+func recordDNSProgrammingLatency(svcs []*object.Service, endpoints *api.Endpoints) {
+	// getLastChangeTriggerTime is the time.Time value of the EndpointsLastChangeTriggerTime
+	// annotation stored in the given endpoints object or the "zero" time if the annotation wasn't set
+	var lastChangeTriggerTime time.Time
+	stringVal, ok := endpoints.Annotations[api.EndpointsLastChangeTriggerTime]
+	if ok {
+		ts, err := time.Parse(time.RFC3339Nano, stringVal)
+		if err != nil {
+			log.Warningf("DnsProgrammingLatency cannot be calculated for Endpoints '%s/%s'; invalid %q annotation RFC3339 value of %q",
+				endpoints.GetNamespace(), endpoints.GetName(), api.EndpointsLastChangeTriggerTime, stringVal)
+			// In case of error val = time.Zero, which is ignored in the upstream code.
+		}
+		lastChangeTriggerTime = ts
+	}
+
+	// isHeadless indicates whether the endpoints object belongs to a headless
+	// service (i.e. clusterIp = None). Note that this can be a  false negatives if the service
+	// informer is lagging, i.e. we may not see a recently created service. Given that the services
+	// don't change very often (comparing to much more frequent endpoints changes), cases when this method
+	// will return wrong answer should be relatively rare. Because of that we intentionally accept this
+	// flaw to keep the solution simple.
+	isHeadless := len(svcs) == 1 && svcs[0].ClusterIP == api.ClusterIPNone
+
+	if endpoints == nil || !isHeadless || lastChangeTriggerTime.IsZero() {
+		return
+	}
+
+	// If we're here it means that the Endpoints object is for a headless service and that
+	// the Endpoints object was created by the endpoints-controller (because the
+	// LastChangeTriggerTime annotation is set). It means that the corresponding service is a
+	// "headless service with selector".
+	DnsProgrammingLatency.WithLabelValues("headless_with_selector").
+		Observe(durationSinceFunc(lastChangeTriggerTime).Seconds())
+}

--- a/coredns/plugin/kubernetes/metrics_test.go
+++ b/coredns/plugin/kubernetes/metrics_test.go
@@ -1,0 +1,137 @@
+package kubernetes
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	namespace = "testns"
+)
+
+func TestDnsProgrammingLatency(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	now := time.Now()
+	ctx := context.TODO()
+	controller := newdnsController(ctx, client, dnsControlOpts{
+		initEndpointsCache: true,
+		// This is needed as otherwise the fake k8s client doesn't work properly.
+		skipAPIObjectsCleanup: true,
+	})
+	durationSinceFunc = func(t time.Time) time.Duration {
+		return now.Sub(t)
+	}
+	DnsProgrammingLatency.Reset()
+	go controller.Run()
+
+	subset1 := []api.EndpointSubset{{
+		Addresses: []api.EndpointAddress{{IP: "1.2.3.4", Hostname: "foo"}},
+	}}
+
+	subset2 := []api.EndpointSubset{{
+		Addresses: []api.EndpointAddress{{IP: "1.2.3.5", Hostname: "foo"}},
+	}}
+
+	createService(t, client, controller, "my-service", api.ClusterIPNone)
+	createEndpoints(t, client, "my-service", now.Add(-2*time.Second), subset1)
+	updateEndpoints(t, client, "my-service", now.Add(-1*time.Second), subset2)
+
+	createEndpoints(t, client, "endpoints-no-service", now.Add(-4*time.Second), nil)
+
+	createService(t, client, controller, "clusterIP-service", "10.40.0.12")
+	createEndpoints(t, client, "clusterIP-service", now.Add(-8*time.Second), nil)
+
+	createService(t, client, controller, "headless-no-annotation", api.ClusterIPNone)
+	createEndpoints(t, client, "headless-no-annotation", nil, nil)
+
+	createService(t, client, controller, "headless-wrong-annotation", api.ClusterIPNone)
+	createEndpoints(t, client, "headless-wrong-annotation", "wrong-value", nil)
+
+	controller.Stop()
+	expected := `
+        # HELP coredns_kubernetes_dns_programming_duration_seconds Histogram of the time (in seconds) it took to program a dns instance.
+        # TYPE coredns_kubernetes_dns_programming_duration_seconds histogram
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.001"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.002"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.004"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.008"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.016"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.032"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.064"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.128"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.256"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.512"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="1.024"} 1
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="2.048"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="4.096"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="8.192"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="16.384"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="32.768"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="65.536"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="131.072"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="262.144"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="524.288"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="+Inf"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_sum{service_kind="headless_with_selector"} 3
+        coredns_kubernetes_dns_programming_duration_seconds_count{service_kind="headless_with_selector"} 2
+	`
+	if err := testutil.CollectAndCompare(DnsProgrammingLatency, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}
+
+func buildEndpoints(name string, lastChangeTriggerTime interface{}, subsets []api.EndpointSubset) *api.Endpoints {
+	annotations := make(map[string]string)
+	switch v := lastChangeTriggerTime.(type) {
+	case string:
+		annotations[api.EndpointsLastChangeTriggerTime] = v
+	case time.Time:
+		annotations[api.EndpointsLastChangeTriggerTime] = v.Format(time.RFC3339Nano)
+	}
+	return &api.Endpoints{
+		ObjectMeta: meta.ObjectMeta{Namespace: namespace, Name: name, Annotations: annotations},
+		Subsets:    subsets,
+	}
+}
+
+func createEndpoints(t *testing.T, client kubernetes.Interface, name string, triggerTime interface{}, subsets []api.EndpointSubset) {
+	ctx := context.TODO()
+	_, err := client.CoreV1().Endpoints(namespace).Create(ctx, buildEndpoints(name, triggerTime, subsets), meta.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func updateEndpoints(t *testing.T, client kubernetes.Interface, name string, triggerTime interface{}, subsets []api.EndpointSubset) {
+	ctx := context.TODO()
+	_, err := client.CoreV1().Endpoints(namespace).Update(ctx, buildEndpoints(name, triggerTime, subsets), meta.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createService(t *testing.T, client kubernetes.Interface, controller dnsController, name string, clusterIp string) {
+	ctx := context.TODO()
+	if _, err := client.CoreV1().Services(namespace).Create(ctx, &api.Service{
+		ObjectMeta: meta.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       api.ServiceSpec{ClusterIP: clusterIp},
+	}, meta.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
+		return len(controller.SvcIndex(object.ServiceKey(name, namespace))) == 1, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/coredns/plugin/kubernetes/namespace.go
+++ b/coredns/plugin/kubernetes/namespace.go
@@ -1,0 +1,30 @@
+package kubernetes
+
+// filteredNamespaceExists checks if namespace exists in this cluster
+// according to any `namespace_labels` plugin configuration specified.
+// Returns true even for namespaces not exposed by plugin configuration,
+// see namespaceExposed.
+func (k *Kubernetes) filteredNamespaceExists(namespace string) bool {
+	ns, err := k.APIConn.GetNamespaceByName(namespace)
+	if err != nil {
+		return false
+	}
+	return ns.ObjectMeta.Name == namespace
+}
+
+// configuredNamespace returns true when the namespace is exposed through the plugin
+// `namespaces` configuration.
+func (k *Kubernetes) configuredNamespace(namespace string) bool {
+	_, ok := k.Namespaces[namespace]
+	if len(k.Namespaces) > 0 && !ok {
+		return false
+	}
+	return true
+}
+
+func (k *Kubernetes) namespaceExposed(namespace string) bool {
+	// return k.configuredNamespace(namespace) && k.filteredNamespaceExists(namespace)
+	// This bug(https://github.com/kubeedge/kubeedge/issues/4582) caused coredns missing
+	// namespace events and make k.filteredNamespaceExists(namespace) returns false for new created namespace
+	return k.configuredNamespace(namespace)
+}

--- a/coredns/plugin/kubernetes/namespace_test.go
+++ b/coredns/plugin/kubernetes/namespace_test.go
@@ -1,0 +1,72 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestFilteredNamespaceExists(t *testing.T) {
+	tests := []struct {
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{}, "foobar"},
+		{false, map[string]struct{}{}, "nsnoexist"},
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.filteredNamespaceExists(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Filtered namespace %s was expected to exist", i, test.testNamespace)
+		}
+	}
+}
+
+func TestNamespaceExposed(t *testing.T) {
+	tests := []struct {
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{"foobar": {}}, "foobar"},
+		{false, map[string]struct{}{"foobar": {}}, "nsnoexist"},
+		{true, map[string]struct{}{}, "foobar"},
+		{true, map[string]struct{}{}, "nsnoexist"},
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.configuredNamespace(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Namespace %s was expected to be exposed", i, test.testNamespace)
+		}
+	}
+}
+
+func TestNamespaceValid(t *testing.T) {
+	tests := []struct {
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{"foobar": {}}, "foobar"},
+		{false, map[string]struct{}{"foobar": {}}, "nsnoexist"},
+		{true, map[string]struct{}{}, "foobar"},
+		{false, map[string]struct{}{}, "nsnoexist"},
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.namespaceExposed(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Namespace %s was expected to be valid", i, test.testNamespace)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/ns.go
+++ b/coredns/plugin/kubernetes/ns.go
@@ -1,0 +1,90 @@
+package kubernetes
+
+import (
+	"net"
+	"strings"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+)
+
+func isDefaultNS(name, zone string) bool {
+	return strings.Index(name, defaultNSName) == 0 && strings.Index(name, zone) == len(defaultNSName)
+}
+
+// nsAddrs returns the A or AAAA records for the CoreDNS service in the cluster. If the service cannot be found,
+// it returns a record for the local address of the machine we're running on.
+func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
+	var (
+		svcNames []string
+		svcIPs   []net.IP
+	)
+
+	// Find the CoreDNS Endpoints
+	for _, localIP := range k.localIPs {
+		endpoints := k.APIConn.EpIndexReverse(localIP.String())
+
+		// Collect IPs for all Services of the Endpoints
+		for _, endpoint := range endpoints {
+			svcs := k.APIConn.SvcIndex(object.ServiceKey(endpoint.Name, endpoint.Namespace))
+			for _, svc := range svcs {
+				if external {
+					svcName := strings.Join([]string{svc.Name, svc.Namespace, zone}, ".")
+					for _, exIP := range svc.ExternalIPs {
+						svcNames = append(svcNames, svcName)
+						svcIPs = append(svcIPs, net.ParseIP(exIP))
+					}
+					continue
+				}
+				svcName := strings.Join([]string{svc.Name, svc.Namespace, Svc, zone}, ".")
+				if svc.ClusterIP == api.ClusterIPNone {
+					// For a headless service, use the endpoints IPs
+					for _, s := range endpoint.Subsets {
+						for _, a := range s.Addresses {
+							svcNames = append(svcNames, endpointHostname(a, k.endpointNameMode)+"."+svcName)
+							svcIPs = append(svcIPs, net.ParseIP(a.IP))
+						}
+					}
+				} else {
+					svcNames = append(svcNames, svcName)
+					svcIPs = append(svcIPs, net.ParseIP(svc.ClusterIP))
+				}
+			}
+		}
+	}
+
+	// If no local IPs matched any endpoints, use the localIPs directly
+	if len(svcIPs) == 0 {
+		svcIPs = make([]net.IP, len(k.localIPs))
+		svcNames = make([]string, len(k.localIPs))
+		for i, localIP := range k.localIPs {
+			svcNames[i] = defaultNSName + zone
+			svcIPs[i] = localIP
+		}
+	}
+
+	// Create an RR slice of collected IPs
+	rrs := make([]dns.RR, len(svcIPs))
+	for i, ip := range svcIPs {
+		if ip.To4() == nil {
+			rr := new(dns.AAAA)
+			rr.Hdr.Class = dns.ClassINET
+			rr.Hdr.Rrtype = dns.TypeAAAA
+			rr.Hdr.Name = svcNames[i]
+			rr.AAAA = ip
+			rrs[i] = rr
+			continue
+		}
+		rr := new(dns.A)
+		rr.Hdr.Class = dns.ClassINET
+		rr.Hdr.Rrtype = dns.TypeA
+		rr.Hdr.Name = svcNames[i]
+		rr.A = ip
+		rrs[i] = rr
+	}
+
+	return rrs
+}
+
+const defaultNSName = "ns.dns."

--- a/coredns/plugin/kubernetes/ns_test.go
+++ b/coredns/plugin/kubernetes/ns_test.go
@@ -1,0 +1,152 @@
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+)
+
+type APIConnTest struct{}
+
+func (APIConnTest) HasSynced() bool                          { return true }
+func (APIConnTest) Run()                                     {}
+func (APIConnTest) Stop() error                              { return nil }
+func (APIConnTest) PodIndex(string) []*object.Pod            { return nil }
+func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }
+func (APIConnTest) EpIndex(string) []*object.Endpoints       { return nil }
+func (APIConnTest) EndpointsList() []*object.Endpoints       { return nil }
+func (APIConnTest) Modified() int64                          { return 0 }
+
+func (a APIConnTest) SvcIndex(s string) []*object.Service {
+	switch s {
+	case "dns-service.kube-system":
+		return []*object.Service{a.ServiceList()[0]}
+	case "hdls-dns-service.kube-system":
+		return []*object.Service{a.ServiceList()[1]}
+	case "dns6-service.kube-system":
+		return []*object.Service{a.ServiceList()[2]}
+	}
+	return nil
+}
+
+func (APIConnTest) ServiceList() []*object.Service {
+	svcs := []*object.Service{
+		{
+			Name:      "dns-service",
+			Namespace: "kube-system",
+			ClusterIP: "10.0.0.111",
+		},
+		{
+			Name:      "hdls-dns-service",
+			Namespace: "kube-system",
+			ClusterIP: api.ClusterIPNone,
+		},
+		{
+			Name:      "dns6-service",
+			Namespace: "kube-system",
+			ClusterIP: "10::111",
+		},
+	}
+	return svcs
+}
+
+func (APIConnTest) EpIndexReverse(ip string) []*object.Endpoints {
+	if ip != "10.244.0.20" {
+		return nil
+	}
+	eps := []*object.Endpoints{
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{
+							IP: "10.244.0.20",
+						},
+					},
+				},
+			},
+			Name:      "dns-service",
+			Namespace: "kube-system",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{
+							IP: "10.244.0.20",
+						},
+					},
+				},
+			},
+			Name:      "hdls-dns-service",
+			Namespace: "kube-system",
+		},
+		{
+			Subsets: []object.EndpointSubset{
+				{
+					Addresses: []object.EndpointAddress{
+						{
+							IP: "10.244.0.20",
+						},
+					},
+				},
+			},
+			Name:      "dns6-service",
+			Namespace: "kube-system",
+		},
+	}
+	return eps
+}
+
+func (APIConnTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+	return &api.Node{}, nil
+}
+func (APIConnTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{}, nil
+}
+
+func TestNsAddrs(t *testing.T) {
+
+	k := New([]string{"inter.webs.test."})
+	k.APIConn = &APIConnTest{}
+	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
+
+	cdrs := k.nsAddrs(false, k.Zones[0])
+
+	if len(cdrs) != 3 {
+		t.Fatalf("Expected 3 results, got %v", len(cdrs))
+
+	}
+	cdr := cdrs[0]
+	expected := "10.0.0.111"
+	if cdr.(*dns.A).A.String() != expected {
+		t.Errorf("Expected 1st A to be %q, got %q", expected, cdr.(*dns.A).A.String())
+	}
+	expected = "dns-service.kube-system.svc.inter.webs.test."
+	if cdr.Header().Name != expected {
+		t.Errorf("Expected 1st Header Name to be %q, got %q", expected, cdr.Header().Name)
+	}
+	cdr = cdrs[1]
+	expected = "10.244.0.20"
+	if cdr.(*dns.A).A.String() != expected {
+		t.Errorf("Expected 2nd A to be %q, got %q", expected, cdr.(*dns.A).A.String())
+	}
+	expected = "10-244-0-20.hdls-dns-service.kube-system.svc.inter.webs.test."
+	if cdr.Header().Name != expected {
+		t.Errorf("Expected 2nd Header Name to be %q, got %q", expected, cdr.Header().Name)
+	}
+	cdr = cdrs[2]
+	expected = "10::111"
+	if cdr.(*dns.AAAA).AAAA.String() != expected {
+		t.Errorf("Expected AAAA to be %q, got %q", expected, cdr.(*dns.A).A.String())
+	}
+	expected = "dns6-service.kube-system.svc.inter.webs.test."
+	if cdr.Header().Name != expected {
+		t.Errorf("Expected AAAA Header Name to be %q, got %q", expected, cdr.Header().Name)
+	}
+}

--- a/coredns/plugin/kubernetes/object/endpoint.go
+++ b/coredns/plugin/kubernetes/object/endpoint.go
@@ -1,0 +1,173 @@
+package object
+
+import (
+	"fmt"
+
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Endpoints is a stripped down api.Endpoints with only the items we need for CoreDNS.
+type Endpoints struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
+	Version   string
+	Name      string
+	Namespace string
+	Index     string
+	IndexIP   []string
+	Subsets   []EndpointSubset
+
+	*Empty
+}
+
+// EndpointSubset is a group of addresses with a common set of ports. The
+// expanded set of endpoints is the Cartesian product of Addresses x Ports.
+type EndpointSubset struct {
+	Addresses []EndpointAddress
+	Ports     []EndpointPort
+}
+
+// EndpointAddress is a tuple that describes single IP address.
+type EndpointAddress struct {
+	IP            string
+	Hostname      string
+	NodeName      string
+	TargetRefName string
+}
+
+// EndpointPort is a tuple that describes a single port.
+type EndpointPort struct {
+	Port     int32
+	Name     string
+	Protocol string
+}
+
+// EndpointsKey returns a string using for the index.
+func EndpointsKey(name, namespace string) string { return name + "." + namespace }
+
+// ToEndpoints returns a function that converts an *api.Endpoints to a *Endpoints.
+func ToEndpoints(skipCleanup bool) ToFunc {
+	return func(obj interface{}) (interface{}, error) {
+		eps, ok := obj.(*api.Endpoints)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object %v", obj)
+		}
+		return toEndpoints(skipCleanup, eps), nil
+	}
+}
+
+// toEndpoints converts an *api.Endpoints to a *Endpoints.
+func toEndpoints(skipCleanup bool, end *api.Endpoints) *Endpoints {
+	e := &Endpoints{
+		Version:   end.GetResourceVersion(),
+		Name:      end.GetName(),
+		Namespace: end.GetNamespace(),
+		Index:     EndpointsKey(end.GetName(), end.GetNamespace()),
+		Subsets:   make([]EndpointSubset, len(end.Subsets)),
+	}
+	for i, eps := range end.Subsets {
+		sub := EndpointSubset{
+			Addresses: make([]EndpointAddress, len(eps.Addresses)),
+		}
+		if len(eps.Ports) == 0 {
+			// Add sentinel if there are no ports.
+			sub.Ports = []EndpointPort{{Port: -1}}
+		} else {
+			sub.Ports = make([]EndpointPort, len(eps.Ports))
+		}
+
+		for j, a := range eps.Addresses {
+			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname}
+			if a.NodeName != nil {
+				ea.NodeName = *a.NodeName
+			}
+			if a.TargetRef != nil {
+				ea.TargetRefName = a.TargetRef.Name
+			}
+			sub.Addresses[j] = ea
+		}
+
+		for k, p := range eps.Ports {
+			ep := EndpointPort{Port: p.Port, Name: p.Name, Protocol: string(p.Protocol)}
+			sub.Ports[k] = ep
+		}
+
+		e.Subsets[i] = sub
+	}
+
+	for _, eps := range end.Subsets {
+		for _, a := range eps.Addresses {
+			e.IndexIP = append(e.IndexIP, a.IP)
+		}
+	}
+
+	if !skipCleanup {
+		*end = api.Endpoints{}
+	}
+
+	return e
+}
+
+// CopyWithoutSubsets copies e, without the subsets.
+func (e *Endpoints) CopyWithoutSubsets() *Endpoints {
+	e1 := &Endpoints{
+		Version:   e.Version,
+		Name:      e.Name,
+		Namespace: e.Namespace,
+		Index:     e.Index,
+		IndexIP:   make([]string, len(e.IndexIP)),
+	}
+	copy(e1.IndexIP, e.IndexIP)
+	return e1
+}
+
+var _ runtime.Object = &Endpoints{}
+
+// DeepCopyObject implements the ObjectKind interface.
+func (e *Endpoints) DeepCopyObject() runtime.Object {
+	e1 := &Endpoints{
+		Version:   e.Version,
+		Name:      e.Name,
+		Namespace: e.Namespace,
+		Index:     e.Index,
+		IndexIP:   make([]string, len(e.IndexIP)),
+		Subsets:   make([]EndpointSubset, len(e.Subsets)),
+	}
+	copy(e1.IndexIP, e.IndexIP)
+
+	for i, eps := range e.Subsets {
+		sub := EndpointSubset{
+			Addresses: make([]EndpointAddress, len(eps.Addresses)),
+			Ports:     make([]EndpointPort, len(eps.Ports)),
+		}
+		for j, a := range eps.Addresses {
+			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname, NodeName: a.NodeName, TargetRefName: a.TargetRefName}
+			sub.Addresses[j] = ea
+		}
+		for k, p := range eps.Ports {
+			ep := EndpointPort{Port: p.Port, Name: p.Name, Protocol: p.Protocol}
+			sub.Ports[k] = ep
+		}
+
+		e1.Subsets[i] = sub
+	}
+	return e1
+}
+
+// GetNamespace implements the metav1.Object interface.
+func (e *Endpoints) GetNamespace() string { return e.Namespace }
+
+// SetNamespace implements the metav1.Object interface.
+func (e *Endpoints) SetNamespace(namespace string) {}
+
+// GetName implements the metav1.Object interface.
+func (e *Endpoints) GetName() string { return e.Name }
+
+// SetName implements the metav1.Object interface.
+func (e *Endpoints) SetName(name string) {}
+
+// GetResourceVersion implements the metav1.Object interface.
+func (e *Endpoints) GetResourceVersion() string { return e.Version }
+
+// SetResourceVersion implements the metav1.Object interface.
+func (e *Endpoints) SetResourceVersion(version string) {}

--- a/coredns/plugin/kubernetes/object/informer.go
+++ b/coredns/plugin/kubernetes/object/informer.go
@@ -1,0 +1,76 @@
+package object
+
+import (
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewIndexerInformer is a copy of the cache.NewIndexerInformer function, but allows custom process function
+func NewIndexerInformer(lw cache.ListerWatcher, objType runtime.Object, h cache.ResourceEventHandler, indexers cache.Indexers, builder ProcessorBuilder) (cache.Indexer, cache.Controller) {
+	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
+
+	cfg := &cache.Config{
+		Queue:            cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, clientState),
+		ListerWatcher:    lw,
+		ObjectType:       objType,
+		FullResyncPeriod: defaultResyncPeriod,
+		RetryOnError:     false,
+		Process:          builder(clientState, h),
+	}
+	return clientState, cache.New(cfg)
+}
+
+type recordLatencyFunc func(meta.Object)
+
+// DefaultProcessor is based on the Process function from cache.NewIndexerInformer except it does a conversion.
+func DefaultProcessor(convert ToFunc, recordLatency recordLatencyFunc) ProcessorBuilder {
+	return func(clientState cache.Indexer, h cache.ResourceEventHandler) cache.ProcessFunc {
+		return func(obj interface{}) error {
+			for _, d := range obj.(cache.Deltas) {
+				switch d.Type {
+				case cache.Sync, cache.Added, cache.Updated:
+					obj, err := convert(d.Object)
+					if err != nil {
+						return err
+					}
+					if old, exists, err := clientState.Get(obj); err == nil && exists {
+						if err := clientState.Update(obj); err != nil {
+							return err
+						}
+						h.OnUpdate(old, obj)
+					} else {
+						if err := clientState.Add(obj); err != nil {
+							return err
+						}
+						h.OnAdd(obj)
+					}
+					if recordLatency != nil {
+						recordLatency(d.Object.(meta.Object))
+					}
+				case cache.Deleted:
+					var obj interface{}
+					obj, ok := d.Object.(cache.DeletedFinalStateUnknown)
+					if !ok {
+						var err error
+						obj, err = convert(d.Object)
+						if err != nil && err != errPodTerminating {
+							return err
+						}
+					}
+
+					if err := clientState.Delete(obj); err != nil {
+						return err
+					}
+					h.OnDelete(obj)
+					if !ok && recordLatency != nil {
+						recordLatency(d.Object.(meta.Object))
+					}
+				}
+			}
+			return nil
+		}
+	}
+}
+
+const defaultResyncPeriod = 0

--- a/coredns/plugin/kubernetes/object/object.go
+++ b/coredns/plugin/kubernetes/object/object.go
@@ -1,0 +1,113 @@
+// Package object holds functions that convert the objects from the k8s API in
+// to a more memory efficient structures.
+//
+// Adding new fields to any of the structures defined in pod.go, endpoint.go
+// and service.go should not be done lightly as this increases the memory use
+// and will leads to OOMs in the k8s scale test.
+//
+// We can do some optimizations here as well. We store IP addresses as strings,
+// this might be moved to uint32 (for v4) for instance, but then we need to
+// convert those again.
+//
+// Also the msg.Service use in this plugin may be deprecated at some point, as
+// we don't use most of those features anyway and would free us from the *etcd*
+// dependency, where msg.Service is defined. And should save some mem/cpu as we
+// convert to and from msg.Services.
+package object
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ToFunc converts one empty interface to another.
+type ToFunc func(interface{}) (interface{}, error)
+
+// ProcessorBuilder returns function to process cache events.
+type ProcessorBuilder func(cache.Indexer, cache.ResourceEventHandler) cache.ProcessFunc
+
+// Empty is an empty struct.
+type Empty struct{}
+
+// GetObjectKind implements the ObjectKind interface as a noop.
+func (e *Empty) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
+// GetGenerateName implements the metav1.Object interface.
+func (e *Empty) GetGenerateName() string { return "" }
+
+// SetGenerateName implements the metav1.Object interface.
+func (e *Empty) SetGenerateName(name string) {}
+
+// GetUID implements the metav1.Object interface.
+func (e *Empty) GetUID() types.UID { return "" }
+
+// SetUID implements the metav1.Object interface.
+func (e *Empty) SetUID(uid types.UID) {}
+
+// GetGeneration implements the metav1.Object interface.
+func (e *Empty) GetGeneration() int64 { return 0 }
+
+// SetGeneration implements the metav1.Object interface.
+func (e *Empty) SetGeneration(generation int64) {}
+
+// GetSelfLink implements the metav1.Object interface.
+func (e *Empty) GetSelfLink() string { return "" }
+
+// SetSelfLink implements the metav1.Object interface.
+func (e *Empty) SetSelfLink(selfLink string) {}
+
+// GetCreationTimestamp implements the metav1.Object interface.
+func (e *Empty) GetCreationTimestamp() v1.Time { return v1.Time{} }
+
+// SetCreationTimestamp implements the metav1.Object interface.
+func (e *Empty) SetCreationTimestamp(timestamp v1.Time) {}
+
+// GetDeletionTimestamp implements the metav1.Object interface.
+func (e *Empty) GetDeletionTimestamp() *v1.Time { return &v1.Time{} }
+
+// SetDeletionTimestamp implements the metav1.Object interface.
+func (e *Empty) SetDeletionTimestamp(timestamp *v1.Time) {}
+
+// GetDeletionGracePeriodSeconds implements the metav1.Object interface.
+func (e *Empty) GetDeletionGracePeriodSeconds() *int64 { return nil }
+
+// SetDeletionGracePeriodSeconds implements the metav1.Object interface.
+func (e *Empty) SetDeletionGracePeriodSeconds(*int64) {}
+
+// GetLabels implements the metav1.Object interface.
+func (e *Empty) GetLabels() map[string]string { return nil }
+
+// SetLabels implements the metav1.Object interface.
+func (e *Empty) SetLabels(labels map[string]string) {}
+
+// GetAnnotations implements the metav1.Object interface.
+func (e *Empty) GetAnnotations() map[string]string { return nil }
+
+// SetAnnotations implements the metav1.Object interface.
+func (e *Empty) SetAnnotations(annotations map[string]string) {}
+
+// GetFinalizers implements the metav1.Object interface.
+func (e *Empty) GetFinalizers() []string { return nil }
+
+// SetFinalizers implements the metav1.Object interface.
+func (e *Empty) SetFinalizers(finalizers []string) {}
+
+// GetOwnerReferences implements the metav1.Object interface.
+func (e *Empty) GetOwnerReferences() []v1.OwnerReference { return nil }
+
+// SetOwnerReferences implements the metav1.Object interface.
+func (e *Empty) SetOwnerReferences([]v1.OwnerReference) {}
+
+// GetClusterName implements the metav1.Object interface.
+func (e *Empty) GetClusterName() string { return "" }
+
+// SetClusterName implements the metav1.Object interface.
+func (e *Empty) SetClusterName(clusterName string) {}
+
+// GetManagedFields implements the metav1.Object interface.
+func (e *Empty) GetManagedFields() []v1.ManagedFieldsEntry { return nil }
+
+// SetManagedFields implements the metav1.Object interface.
+func (e *Empty) SetManagedFields(managedFields []v1.ManagedFieldsEntry) {}

--- a/coredns/plugin/kubernetes/object/pod.go
+++ b/coredns/plugin/kubernetes/object/pod.go
@@ -1,0 +1,86 @@
+package object
+
+import (
+	"errors"
+	"fmt"
+
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Pod is a stripped down api.Pod with only the items we need for CoreDNS.
+type Pod struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
+	Version   string
+	PodIP     string
+	Name      string
+	Namespace string
+
+	*Empty
+}
+
+var errPodTerminating = errors.New("pod terminating")
+
+// ToPod returns a function that converts an api.Pod to a *Pod.
+func ToPod(skipCleanup bool) ToFunc {
+	return func(obj interface{}) (interface{}, error) {
+		apiPod, ok := obj.(*api.Pod)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object %v", obj)
+		}
+		pod := toPod(skipCleanup, apiPod)
+		t := apiPod.ObjectMeta.DeletionTimestamp
+		if t != nil && !(*t).Time.IsZero() {
+			// if the pod is in the process of termination, return an error so it can be ignored
+			// during add/update event processing
+			return pod, errPodTerminating
+		}
+		return pod, nil
+	}
+}
+
+func toPod(skipCleanup bool, pod *api.Pod) *Pod {
+	p := &Pod{
+		Version:   pod.GetResourceVersion(),
+		PodIP:     pod.Status.PodIP,
+		Namespace: pod.GetNamespace(),
+		Name:      pod.GetName(),
+	}
+
+	if !skipCleanup {
+		*pod = api.Pod{}
+	}
+
+	return p
+}
+
+var _ runtime.Object = &Pod{}
+
+// DeepCopyObject implements the ObjectKind interface.
+func (p *Pod) DeepCopyObject() runtime.Object {
+	p1 := &Pod{
+		Version:   p.Version,
+		PodIP:     p.PodIP,
+		Namespace: p.Namespace,
+		Name:      p.Name,
+	}
+	return p1
+}
+
+// GetNamespace implements the metav1.Object interface.
+func (p *Pod) GetNamespace() string { return p.Namespace }
+
+// SetNamespace implements the metav1.Object interface.
+func (p *Pod) SetNamespace(namespace string) {}
+
+// GetName implements the metav1.Object interface.
+func (p *Pod) GetName() string { return p.Name }
+
+// SetName implements the metav1.Object interface.
+func (p *Pod) SetName(name string) {}
+
+// GetResourceVersion implements the metav1.Object interface.
+func (p *Pod) GetResourceVersion() string { return p.Version }
+
+// SetResourceVersion implements the metav1.Object interface.
+func (p *Pod) SetResourceVersion(version string) {}

--- a/coredns/plugin/kubernetes/object/service.go
+++ b/coredns/plugin/kubernetes/object/service.go
@@ -1,0 +1,116 @@
+package object
+
+import (
+	"fmt"
+
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Service is a stripped down api.Service with only the items we need for CoreDNS.
+type Service struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
+	Version      string
+	Name         string
+	Namespace    string
+	Index        string
+	ClusterIP    string
+	Type         api.ServiceType
+	ExternalName string
+	Ports        []api.ServicePort
+
+	// ExternalIPs we may want to export.
+	ExternalIPs []string
+
+	*Empty
+}
+
+// ServiceKey returns a string using for the index.
+func ServiceKey(name, namespace string) string { return name + "." + namespace }
+
+// ToService returns a function that converts an api.Service to a *Service.
+func ToService(skipCleanup bool) ToFunc {
+	return func(obj interface{}) (interface{}, error) {
+		svc, ok := obj.(*api.Service)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object %v", obj)
+		}
+		return toService(skipCleanup, svc), nil
+	}
+}
+
+func toService(skipCleanup bool, svc *api.Service) *Service {
+	s := &Service{
+		Version:      svc.GetResourceVersion(),
+		Name:         svc.GetName(),
+		Namespace:    svc.GetNamespace(),
+		Index:        ServiceKey(svc.GetName(), svc.GetNamespace()),
+		ClusterIP:    svc.Spec.ClusterIP,
+		Type:         svc.Spec.Type,
+		ExternalName: svc.Spec.ExternalName,
+
+		ExternalIPs: make([]string, len(svc.Status.LoadBalancer.Ingress)+len(svc.Spec.ExternalIPs)),
+	}
+
+	if len(svc.Spec.Ports) == 0 {
+		// Add sentinel if there are no ports.
+		s.Ports = []api.ServicePort{{Port: -1}}
+	} else {
+		s.Ports = make([]api.ServicePort, len(svc.Spec.Ports))
+		copy(s.Ports, svc.Spec.Ports)
+	}
+
+	li := copy(s.ExternalIPs, svc.Spec.ExternalIPs)
+	for i, lb := range svc.Status.LoadBalancer.Ingress {
+		if lb.IP != "" {
+			s.ExternalIPs[li+i] = lb.IP
+			continue
+		}
+		s.ExternalIPs[li+i] = lb.Hostname
+
+	}
+
+	if !skipCleanup {
+		*svc = api.Service{}
+	}
+
+	return s
+}
+
+var _ runtime.Object = &Service{}
+
+// DeepCopyObject implements the ObjectKind interface.
+func (s *Service) DeepCopyObject() runtime.Object {
+	s1 := &Service{
+		Version:      s.Version,
+		Name:         s.Name,
+		Namespace:    s.Namespace,
+		Index:        s.Index,
+		ClusterIP:    s.ClusterIP,
+		Type:         s.Type,
+		ExternalName: s.ExternalName,
+		Ports:        make([]api.ServicePort, len(s.Ports)),
+		ExternalIPs:  make([]string, len(s.ExternalIPs)),
+	}
+	copy(s1.Ports, s.Ports)
+	copy(s1.ExternalIPs, s.ExternalIPs)
+	return s1
+}
+
+// GetNamespace implements the metav1.Object interface.
+func (s *Service) GetNamespace() string { return s.Namespace }
+
+// SetNamespace implements the metav1.Object interface.
+func (s *Service) SetNamespace(namespace string) {}
+
+// GetName implements the metav1.Object interface.
+func (s *Service) GetName() string { return s.Name }
+
+// SetName implements the metav1.Object interface.
+func (s *Service) SetName(name string) {}
+
+// GetResourceVersion implements the metav1.Object interface.
+func (s *Service) GetResourceVersion() string { return s.Version }
+
+// SetResourceVersion implements the metav1.Object interface.
+func (s *Service) SetResourceVersion(version string) {}

--- a/coredns/plugin/kubernetes/parse.go
+++ b/coredns/plugin/kubernetes/parse.go
@@ -1,0 +1,112 @@
+package kubernetes
+
+import (
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/miekg/dns"
+)
+
+type recordRequest struct {
+	// The named port from the kubernetes DNS spec, this is the service part (think _https) from a well formed
+	// SRV record.
+	port string
+	// The protocol is usually _udp or _tcp (if set), and comes from the protocol part of a well formed
+	// SRV record.
+	protocol string
+	endpoint string
+	// The servicename used in Kubernetes.
+	service string
+	// The namespace used in Kubernetes.
+	namespace string
+	// A each name can be for a pod or a service, here we track what we've seen, either "pod" or "service".
+	podOrSvc string
+}
+
+// parseRequest parses the qname to find all the elements we need for querying k8s. Anything
+// that is not parsed will have the wildcard "*" value (except r.endpoint).
+// Potential underscores are stripped from _port and _protocol.
+func parseRequest(name, zone string) (r recordRequest, err error) {
+	// 3 Possible cases:
+	// 1. _port._protocol.service.namespace.pod|svc.zone
+	// 2. (endpoint): endpoint.service.namespace.pod|svc.zone
+	// 3. (service): service.namespace.pod|svc.zone
+
+	base, _ := dnsutil.TrimZone(name, zone)
+	// return NODATA for apex queries
+	if base == "" || base == Svc || base == Pod {
+		return r, nil
+	}
+	segs := dns.SplitDomainName(base)
+
+	r.port = "*"
+	r.protocol = "*"
+	// for r.name, r.namespace and r.endpoint, we need to know if they have been set or not...
+	// For endpoint: if empty we should skip the endpoint check in k.get(). Hence we cannot set if to "*".
+	// For name: myns.svc.cluster.local != *.myns.svc.cluster.local
+	// For namespace: svc.cluster.local != *.svc.cluster.local
+
+	// start at the right and fill out recordRequest with the bits we find, so we look for
+	// pod|svc.namespace.service and then either
+	// * endpoint
+	// *_protocol._port
+
+	last := len(segs) - 1
+	if last < 0 {
+		return r, nil
+	}
+	r.podOrSvc = segs[last]
+	if r.podOrSvc != Pod && r.podOrSvc != Svc {
+		return r, errInvalidRequest
+	}
+	last--
+	if last < 0 {
+		return r, nil
+	}
+
+	r.namespace = segs[last]
+	last--
+	if last < 0 {
+		return r, nil
+	}
+
+	r.service = segs[last]
+	last--
+	if last < 0 {
+		return r, nil
+	}
+
+	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol.
+	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
+	switch last {
+
+	case 0: // endpoint only
+		r.endpoint = segs[last]
+	case 1: // service and port
+		r.protocol = stripUnderscore(segs[last])
+		r.port = stripUnderscore(segs[last-1])
+
+	default: // too long
+		return r, errInvalidRequest
+	}
+
+	return r, nil
+}
+
+// stripUnderscore removes a prefixed underscore from s.
+func stripUnderscore(s string) string {
+	if s[0] != '_' {
+		return s
+	}
+	return s[1:]
+}
+
+// String returns a string representation of r, it just returns all fields concatenated with dots.
+// This is mostly used in tests.
+func (r recordRequest) String() string {
+	s := r.port
+	s += "." + r.protocol
+	s += "." + r.endpoint
+	s += "." + r.service
+	s += "." + r.namespace
+	s += "." + r.podOrSvc
+	return s
+}

--- a/coredns/plugin/kubernetes/parse_test.go
+++ b/coredns/plugin/kubernetes/parse_test.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestParseRequest(t *testing.T) {
+	tests := []struct {
+		query    string
+		expected string // output from r.String()
+	}{
+		// valid SRV request
+		{"_http._tcp.webs.mynamespace.svc.inter.webs.tests.", "http.tcp..webs.mynamespace.svc"},
+		// wildcard acceptance
+		{"*.any.*.any.svc.inter.webs.tests.", "*.any..*.any.svc"},
+		// A request of endpoint
+		{"1-2-3-4.webs.mynamespace.svc.inter.webs.tests.", "*.*.1-2-3-4.webs.mynamespace.svc"},
+		// bare zone
+		{"inter.webs.tests.", "....."},
+		// bare svc type
+		{"svc.inter.webs.tests.", "....."},
+		// bare pod type
+		{"pod.inter.webs.tests.", "....."},
+	}
+	for i, tc := range tests {
+		m := new(dns.Msg)
+		m.SetQuestion(tc.query, dns.TypeA)
+		state := request.Request{Zone: zone, Req: m}
+
+		r, e := parseRequest(state.Name(), state.Zone)
+		if e != nil {
+			t.Errorf("Test %d, expected no error, got '%v'.", i, e)
+		}
+		rs := r.String()
+		if rs != tc.expected {
+			t.Errorf("Test %d, expected (stringified) recordRequest: %s, got %s", i, tc.expected, rs)
+		}
+	}
+}
+
+func TestParseInvalidRequest(t *testing.T) {
+	invalid := []string{
+		"webs.mynamespace.pood.inter.webs.test.",                 // Request must be for pod or svc subdomain.
+		"too.long.for.what.I.am.trying.to.pod.inter.webs.tests.", // Too long.
+	}
+
+	for i, query := range invalid {
+		m := new(dns.Msg)
+		m.SetQuestion(query, dns.TypeA)
+		state := request.Request{Zone: zone, Req: m}
+
+		if _, e := parseRequest(state.Name(), state.Zone); e == nil {
+			t.Errorf("Test %d: expected error from %s, got none", i, query)
+		}
+	}
+}
+
+const zone = "inter.webs.tests."

--- a/coredns/plugin/kubernetes/ready.go
+++ b/coredns/plugin/kubernetes/ready.go
@@ -1,0 +1,4 @@
+package kubernetes
+
+// Ready implements the ready.Readiness interface.
+func (k *Kubernetes) Ready() bool { return k.APIConn.HasSynced() }

--- a/coredns/plugin/kubernetes/reverse.go
+++ b/coredns/plugin/kubernetes/reverse.go
@@ -1,0 +1,56 @@
+package kubernetes
+
+import (
+	"context"
+	"strings"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/coredns/coredns/request"
+)
+
+// Reverse implements the ServiceBackend interface.
+func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
+
+	ip := dnsutil.ExtractAddressFromReverse(state.Name())
+	if ip == "" {
+		_, e := k.Records(ctx, state, exact)
+		return nil, e
+	}
+
+	records := k.serviceRecordForIP(ip, state.Name())
+	if len(records) == 0 {
+		return records, errNoItems
+	}
+	return records, nil
+}
+
+// serviceRecordForIP gets a service record with a cluster ip matching the ip argument
+// If a service cluster ip does not match, it checks all endpoints
+func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
+	// First check services with cluster ips
+	for _, service := range k.APIConn.SvcIndexReverse(ip) {
+		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {
+			continue
+		}
+		domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
+		return []msg.Service{{Host: domain, TTL: k.ttl}}
+	}
+	// If no cluster ips match, search endpoints
+	var svcs []msg.Service
+	for _, ep := range k.APIConn.EpIndexReverse(ip) {
+		if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.Namespace) {
+			continue
+		}
+		for _, eps := range ep.Subsets {
+			for _, addr := range eps.Addresses {
+				if addr.IP == ip {
+					domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.Name, ep.Namespace, Svc, k.primaryZone()}, ".")
+					svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
+				}
+			}
+		}
+	}
+	return svcs
+}

--- a/coredns/plugin/kubernetes/reverse_test.go
+++ b/coredns/plugin/kubernetes/reverse_test.go
@@ -1,0 +1,228 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type APIConnReverseTest struct{}
+
+func (APIConnReverseTest) HasSynced() bool                    { return true }
+func (APIConnReverseTest) Run()                               {}
+func (APIConnReverseTest) Stop() error                        { return nil }
+func (APIConnReverseTest) PodIndex(string) []*object.Pod      { return nil }
+func (APIConnReverseTest) EpIndex(string) []*object.Endpoints { return nil }
+func (APIConnReverseTest) EndpointsList() []*object.Endpoints { return nil }
+func (APIConnReverseTest) ServiceList() []*object.Service     { return nil }
+func (APIConnReverseTest) Modified() int64                    { return 0 }
+
+func (APIConnReverseTest) SvcIndex(svc string) []*object.Service {
+	if svc != "svc1.testns" {
+		return nil
+	}
+	svcs := []*object.Service{
+		{
+			Name:      "svc1",
+			Namespace: "testns",
+			ClusterIP: "192.168.1.100",
+			Ports:     []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	}
+	return svcs
+
+}
+
+func (APIConnReverseTest) SvcIndexReverse(ip string) []*object.Service {
+	if ip != "192.168.1.100" {
+		return nil
+	}
+	svcs := []*object.Service{
+		{
+			Name:      "svc1",
+			Namespace: "testns",
+			ClusterIP: "192.168.1.100",
+			Ports:     []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	}
+	return svcs
+}
+
+func (APIConnReverseTest) EpIndexReverse(ip string) []*object.Endpoints {
+	ep1 := object.Endpoints{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "10.0.0.100", Hostname: "ep1a"},
+					{IP: "1234:abcd::1", Hostname: "ep1b"},
+					{IP: "fd00:77:30::a", Hostname: "ip6svc1ex"},
+					{IP: "fd00:77:30::2:9ba6", Hostname: "ip6svc1in"},
+					{IP: "10.0.0.99", Hostname: "double-ep"}, // this endpoint is used by two services
+				},
+				Ports: []object.EndpointPort{
+					{Port: 80, Protocol: "tcp", Name: "http"},
+				},
+			},
+		},
+		Name:      "svc1",
+		Namespace: "testns",
+	}
+	ep2 := object.Endpoints{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "10.0.0.99", Hostname: "double-ep"}, // this endpoint is used by two services
+				},
+				Ports: []object.EndpointPort{
+					{Port: 80, Protocol: "tcp", Name: "http"},
+				},
+			},
+		},
+		Name:      "svc2",
+		Namespace: "testns",
+	}
+	switch ip {
+	case "10.0.0.100":
+		fallthrough
+	case "1234:abcd::1":
+		fallthrough
+	case "fd00:77:30::a":
+		fallthrough
+	case "fd00:77:30::2:9ba6":
+		return []*object.Endpoints{&ep1}
+	case "10.0.0.99":
+		return []*object.Endpoints{&ep1, &ep2}
+	}
+	return nil
+}
+
+func (APIConnReverseTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+	return &api.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "test.node.foo.bar",
+		},
+	}, nil
+}
+
+func (APIConnReverseTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}
+
+func TestReverse(t *testing.T) {
+
+	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa."})
+	k.APIConn = &APIConnReverseTest{}
+
+	tests := []test.Case{
+		{
+			Qname: "100.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("100.0.0.10.in-addr.arpa.      5    IN      PTR       ep1a.svc1.testns.svc.cluster.local."),
+			},
+		},
+		{
+			Qname: "100.1.168.192.in-addr.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("100.1.168.192.in-addr.arpa.     5     IN      PTR       svc1.testns.svc.cluster.local."),
+			},
+		},
+		{ // A PTR record query for an existing ipv6 endpoint should return a record
+			Qname: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 5 IN PTR ep1b.svc1.testns.svc.cluster.local."),
+			},
+		},
+		{ // A PTR record query for an existing ipv6 endpoint should return a record
+			Qname: "a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa. 5 IN PTR ip6svc1ex.svc1.testns.svc.cluster.local."),
+			},
+		},
+		{ // A PTR record query for an existing ipv6 endpoint should return a record
+			Qname: "6.a.b.9.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("6.a.b.9.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa. 5 IN PTR ip6svc1in.svc1.testns.svc.cluster.local."),
+			},
+		},
+		{
+			Qname: "101.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeNameError,
+			Ns: []dns.RR{
+				test.SOA("0.10.in-addr.arpa.	5	IN	SOA	ns.dns.0.10.in-addr.arpa. hostmaster.0.10.in-addr.arpa. 1502782828 7200 1800 86400 5"),
+			},
+		},
+		{
+			Qname: "example.org.cluster.local.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeNameError,
+			Ns: []dns.RR{
+				test.SOA("cluster.local.       5     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1502989566 7200 1800 86400 5"),
+			},
+		},
+		{
+			Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Ns: []dns.RR{
+				test.SOA("cluster.local.       5     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1502989566 7200 1800 86400 5"),
+			},
+		},
+		{
+			Qname: "svc1.testns.svc.0.10.in-addr.arpa.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeNameError,
+			Ns: []dns.RR{
+				test.SOA("0.10.in-addr.arpa.       5     IN      SOA     ns.dns.0.10.in-addr.arpa. hostmaster.0.10.in-addr.arpa. 1502989566 7200 1800 86400 5"),
+			},
+		},
+		{
+			Qname: "100.0.0.10.cluster.local.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeNameError,
+			Ns: []dns.RR{
+				test.SOA("cluster.local.       5     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1502989566 7200 1800 86400 5"),
+			},
+		},
+		{
+			Qname: "99.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("99.0.0.10.in-addr.arpa.      5    IN      PTR       double-ep.svc1.testns.svc.cluster.local."),
+				test.PTR("99.0.0.10.in-addr.arpa.      5    IN      PTR       double-ep.svc2.testns.svc.cluster.local."),
+			},
+		},
+	}
+
+	ctx := context.TODO()
+	for i, tc := range tests {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d: expected no error, got %v", i, err)
+			return
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d: got nil message and no error for: %s %d", i, r.Question[0].Name, r.Question[0].Qtype)
+		}
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/setup.go
+++ b/coredns/plugin/kubernetes/setup.go
@@ -1,0 +1,283 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
+
+	"github.com/miekg/dns"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"       // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"      // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
+	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+)
+
+const pluginName = "kubernetes"
+
+var log = clog.NewWithPlugin(pluginName)
+
+func init() { plugin.Register(pluginName, setup) }
+
+func setup(c *caddy.Controller) error {
+	klog.SetOutput(os.Stdout)
+
+	k, err := kubernetesParse(c)
+	if err != nil {
+		return plugin.Error(pluginName, err)
+	}
+
+	err = k.InitKubeCache(context.Background())
+	if err != nil {
+		return plugin.Error(pluginName, err)
+	}
+
+	k.RegisterKubeCache(c)
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		k.Next = next
+		return k
+	})
+
+	// get locally bound addresses
+	c.OnStartup(func() error {
+		k.localIPs = boundIPs(c)
+		return nil
+	})
+
+	return nil
+}
+
+// RegisterKubeCache registers KubeCache start and stop functions with Caddy
+func (k *Kubernetes) RegisterKubeCache(c *caddy.Controller) {
+	c.OnStartup(func() error {
+		go k.APIConn.Run()
+
+		timeout := time.After(5 * time.Second)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		for {
+			select {
+			case <-ticker.C:
+				if k.APIConn.HasSynced() {
+					return nil
+				}
+			case <-timeout:
+				return nil
+			}
+		}
+	})
+
+	c.OnShutdown(func() error {
+		return k.APIConn.Stop()
+	})
+}
+
+func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
+	var (
+		k8s *Kubernetes
+		err error
+	)
+
+	i := 0
+	for c.Next() {
+		if i > 0 {
+			return nil, plugin.ErrOnce
+		}
+		i++
+
+		k8s, err = ParseStanza(c)
+		if err != nil {
+			return k8s, err
+		}
+	}
+	return k8s, nil
+}
+
+// ParseStanza parses a kubernetes stanza
+func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
+
+	k8s := New([]string{""})
+	k8s.autoPathSearch = searchFromResolvConf()
+
+	opts := dnsControlOpts{
+		initEndpointsCache: true,
+		ignoreEmptyService: false,
+	}
+	k8s.opts = opts
+
+	zones := c.RemainingArgs()
+
+	if len(zones) != 0 {
+		k8s.Zones = zones
+		for i := 0; i < len(k8s.Zones); i++ {
+			k8s.Zones[i] = plugin.Host(k8s.Zones[i]).Normalize()
+		}
+	} else {
+		k8s.Zones = make([]string, len(c.ServerBlockKeys))
+		for i := 0; i < len(c.ServerBlockKeys); i++ {
+			k8s.Zones[i] = plugin.Host(c.ServerBlockKeys[i]).Normalize()
+		}
+	}
+
+	k8s.primaryZoneIndex = -1
+	for i, z := range k8s.Zones {
+		if dnsutil.IsReverse(z) > 0 {
+			continue
+		}
+		k8s.primaryZoneIndex = i
+		break
+	}
+
+	if k8s.primaryZoneIndex == -1 {
+		return nil, errors.New("non-reverse zone name must be used")
+	}
+
+	k8s.Upstream = upstream.New()
+
+	for c.NextBlock() {
+		switch c.Val() {
+		case "endpoint_pod_names":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				return nil, c.ArgErr()
+			}
+			k8s.endpointNameMode = true
+			continue
+		case "pods":
+			args := c.RemainingArgs()
+			if len(args) == 1 {
+				switch args[0] {
+				case podModeDisabled, podModeInsecure, podModeVerified:
+					k8s.podMode = args[0]
+				default:
+					return nil, fmt.Errorf("wrong value for pods: %s,  must be one of: disabled, verified, insecure", args[0])
+				}
+				continue
+			}
+			return nil, c.ArgErr()
+		case "namespaces":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				for _, a := range args {
+					k8s.Namespaces[a] = struct{}{}
+				}
+				continue
+			}
+			return nil, c.ArgErr()
+		case "endpoint":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				// Multiple endpoints are deprecated but still could be specified,
+				// only the first one be used, though
+				k8s.APIServerList = args
+				if len(args) > 1 {
+					log.Warningf("Multiple endpoints have been deprecated, only the first specified endpoint '%s' is used", args[0])
+				}
+				continue
+			}
+			return nil, c.ArgErr()
+		case "tls": // cert key cacertfile
+			args := c.RemainingArgs()
+			if len(args) == 3 {
+				k8s.APIClientCert, k8s.APIClientKey, k8s.APICertAuth = args[0], args[1], args[2]
+				continue
+			}
+			return nil, c.ArgErr()
+		case "labels":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				labelSelectorString := strings.Join(args, " ")
+				ls, err := meta.ParseToLabelSelector(labelSelectorString)
+				if err != nil {
+					return nil, fmt.Errorf("unable to parse label selector value: '%v': %v", labelSelectorString, err)
+				}
+				k8s.opts.labelSelector = ls
+				continue
+			}
+			return nil, c.ArgErr()
+		case "namespace_labels":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				namespaceLabelSelectorString := strings.Join(args, " ")
+				nls, err := meta.ParseToLabelSelector(namespaceLabelSelectorString)
+				if err != nil {
+					return nil, fmt.Errorf("unable to parse namespace_label selector value: '%v': %v", namespaceLabelSelectorString, err)
+				}
+				k8s.opts.namespaceLabelSelector = nls
+				continue
+			}
+			return nil, c.ArgErr()
+		case "fallthrough":
+			k8s.Fall.SetZonesFromArgs(c.RemainingArgs())
+		case "ttl":
+			args := c.RemainingArgs()
+			if len(args) == 0 {
+				return nil, c.ArgErr()
+			}
+			t, err := strconv.Atoi(args[0])
+			if err != nil {
+				return nil, err
+			}
+			if t < 0 || t > 3600 {
+				return nil, c.Errf("ttl must be in range [0, 3600]: %d", t)
+			}
+			k8s.ttl = uint32(t)
+		case "noendpoints":
+			if len(c.RemainingArgs()) != 0 {
+				return nil, c.ArgErr()
+			}
+			k8s.opts.initEndpointsCache = false
+		case "ignore":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				ignore := args[0]
+				if ignore == "empty_service" {
+					k8s.opts.ignoreEmptyService = true
+					continue
+				} else {
+					return nil, fmt.Errorf("unable to parse ignore value: '%v'", ignore)
+				}
+			}
+		case "kubeconfig":
+			args := c.RemainingArgs()
+			if len(args) == 2 {
+				config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+					&clientcmd.ClientConfigLoadingRules{ExplicitPath: args[0]},
+					&clientcmd.ConfigOverrides{CurrentContext: args[1]},
+				)
+				k8s.ClientConfig = config
+				continue
+			}
+			return nil, c.ArgErr()
+		default:
+			return nil, c.Errf("unknown property '%s'", c.Val())
+		}
+	}
+
+	if len(k8s.Namespaces) != 0 && k8s.opts.namespaceLabelSelector != nil {
+		return nil, c.Errf("namespaces and namespace_labels cannot both be set")
+	}
+
+	return k8s, nil
+}
+
+func searchFromResolvConf() []string {
+	rc, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		return nil
+	}
+	plugin.Zones(rc.Search).Normalize()
+	return rc.Search
+}

--- a/coredns/plugin/kubernetes/setup_reverse_test.go
+++ b/coredns/plugin/kubernetes/setup_reverse_test.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/caddy"
+)
+
+func TestKubernetesParseReverseZone(t *testing.T) {
+	tests := []struct {
+		input         string   // Corefile data as string
+		expectedZones []string // expected count of defined zones.
+	}{
+		{`kubernetes coredns.local 10.0.0.0/16`, []string{"coredns.local.", "0.10.in-addr.arpa."}},
+		{`kubernetes coredns.local 10.0.0.0/17`, []string{"coredns.local.", "0.10.in-addr.arpa."}},
+		{`kubernetes coredns.local fd00:77:30::0/110`, []string{"coredns.local.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa."}},
+	}
+
+	for i, tc := range tests {
+		c := caddy.NewTestController("dns", tc.input)
+		k, err := kubernetesParse(c)
+		if err != nil {
+			t.Fatalf("Test %d: Expected no error, got %q", i, err)
+		}
+
+		zl := len(k.Zones)
+		if zl != len(tc.expectedZones) {
+			t.Errorf("Test %d: Expected kubernetes to be initialized with %d zones, found %d zones", i, len(tc.expectedZones), zl)
+		}
+		for i, z := range tc.expectedZones {
+			if k.Zones[i] != z {
+				t.Errorf("Test %d: Expected zones to be %q, got %q", i, z, k.Zones[i])
+			}
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/setup_test.go
+++ b/coredns/plugin/kubernetes/setup_test.go
@@ -1,0 +1,599 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/plugin/pkg/fall"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKubernetesParse(t *testing.T) {
+	tests := []struct {
+		input                          string // Corefile data as string
+		shouldErr                      bool   // true if test case is expected to produce an error.
+		expectedErrContent             string // substring from the expected error. Empty for positive cases.
+		expectedZoneCount              int    // expected count of defined zones.
+		expectedNSCount                int    // expected count of namespaces.
+		expectedLabelSelector          string // expected label selector value
+		expectedNamespaceLabelSelector string // expected namespace label selector value
+		expectedPodMode                string
+		expectedFallthrough            fall.F
+	}{
+		// positive
+		{
+			`kubernetes coredns.local`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local test.local`,
+			false,
+			"",
+			2,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	endpoint http://localhost:9090 http://localhost:9091
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	namespaces demo
+}`,
+			false,
+			"",
+			1,
+			1,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	namespaces demo test
+}`,
+			false,
+			"",
+			1,
+			2,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    labels environment=prod
+}`,
+			false,
+			"",
+			1,
+			0,
+			"environment=prod",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    labels environment in (production, staging, qa),application=nginx
+}`,
+			false,
+			"",
+			1,
+			0,
+			"application=nginx,environment in (production,qa,staging)",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    namespace_labels istio-injection=enabled
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"istio-injection=enabled",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    namespaces foo bar
+    namespace_labels istio-injection=enabled
+}`,
+			true,
+			"Error during parsing: namespaces and namespace_labels cannot both be set",
+			-1,
+			0,
+			"",
+			"istio-injection=enabled",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local test.local {
+	endpoint http://localhost:8080
+	namespaces demo test
+    labels environment in (production, staging, qa),application=nginx
+    fallthrough
+}`,
+			false,
+			"",
+			2,
+			2,
+			"application=nginx,environment in (production,qa,staging)",
+			"",
+			podModeDisabled,
+			fall.Root,
+		},
+		// negative
+		{
+			`kubernetes coredns.local {
+    endpoint
+}`,
+			true,
+			"rong argument count or unexpected line ending",
+			-1,
+			-1,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	namespaces
+}`,
+			true,
+			"rong argument count or unexpected line ending",
+			-1,
+			-1,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    labels
+}`,
+			true,
+			"rong argument count or unexpected line ending",
+			-1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    labels environment in (production, qa
+}`,
+			true,
+			"unable to parse label selector",
+			-1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		// pods disabled
+		{
+			`kubernetes coredns.local {
+	pods disabled
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		// pods insecure
+		{
+			`kubernetes coredns.local {
+	pods insecure
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeInsecure,
+			fall.Zero,
+		},
+		// pods verified
+		{
+			`kubernetes coredns.local {
+	pods verified
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeVerified,
+			fall.Zero,
+		},
+		// pods invalid
+		{
+			`kubernetes coredns.local {
+	pods giant_seed
+}`,
+			true,
+			"rong value for pods",
+			-1,
+			0,
+			"",
+			"",
+			podModeVerified,
+			fall.Zero,
+		},
+		// fallthrough with zones
+		{
+			`kubernetes coredns.local {
+	fallthrough ip6.arpa inaddr.arpa foo.com
+}`,
+			false,
+			"rong argument count",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.F{Zones: []string{"ip6.arpa.", "inaddr.arpa.", "foo.com."}},
+		},
+		// More than one Kubernetes not allowed
+		{
+			`kubernetes coredns.local
+kubernetes cluster.local`,
+			true,
+			"this plugin",
+			-1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	kubeconfig
+}`,
+			true,
+			"Wrong argument count or unexpected line ending after",
+			-1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	kubeconfig file context extraarg
+}`,
+			true,
+			"Wrong argument count or unexpected line ending after",
+			-1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+	kubeconfig file context
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		k8sController, err := kubernetesParse(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but did not find error for input '%s'. Error was: '%v'", i, test.input, err)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				continue
+			}
+
+			if test.shouldErr && (len(test.expectedErrContent) < 1) {
+				t.Fatalf("Test %d: Test marked as expecting an error, but no expectedErrContent provided for input '%s'. Error was: '%v'", i, test.input, err)
+			}
+
+			if test.shouldErr && (test.expectedZoneCount >= 0) {
+				t.Errorf("Test %d: Test marked as expecting an error, but provides value for expectedZoneCount!=-1 for input '%s'. Error was: '%v'", i, test.input, err)
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+			}
+			continue
+		}
+
+		// No error was raised, so validate initialization of k8sController
+		//     Zones
+		foundZoneCount := len(k8sController.Zones)
+		if foundZoneCount != test.expectedZoneCount {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with %d zones, instead found %d zones: '%v' for input '%s'", i, test.expectedZoneCount, foundZoneCount, k8sController.Zones, test.input)
+		}
+
+		//    Namespaces
+		foundNSCount := len(k8sController.Namespaces)
+		if foundNSCount != test.expectedNSCount {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with %d namespaces. Instead found %d namespaces: '%v' for input '%s'", i, test.expectedNSCount, foundNSCount, k8sController.Namespaces, test.input)
+		}
+
+		//    Labels
+		if k8sController.opts.labelSelector != nil {
+			foundLabelSelectorString := meta.FormatLabelSelector(k8sController.opts.labelSelector)
+			if foundLabelSelectorString != test.expectedLabelSelector {
+				t.Errorf("Test %d: Expected kubernetes controller to be initialized with label selector '%s'. Instead found selector '%s' for input '%s'", i, test.expectedLabelSelector, foundLabelSelectorString, test.input)
+			}
+		}
+		//    Pods
+		foundPodMode := k8sController.podMode
+		if foundPodMode != test.expectedPodMode {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with pod mode '%s'. Instead found pod mode '%s' for input '%s'", i, test.expectedPodMode, foundPodMode, test.input)
+		}
+
+		// fallthrough
+		if !k8sController.Fall.Equal(test.expectedFallthrough) {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with fallthrough '%v'. Instead found fallthrough '%v' for input '%s'", i, test.expectedFallthrough, k8sController.Fall, test.input)
+		}
+	}
+}
+
+func TestKubernetesParseEndpointPodNames(t *testing.T) {
+	tests := []struct {
+		input                string // Corefile data as string
+		shouldErr            bool   // true if test case is expected to produce an error.
+		expectedErrContent   string // substring from the expected error. Empty for positive cases.
+		expectedEndpointMode bool
+	}{
+		// valid endpoints mode
+		{
+			`kubernetes coredns.local {
+	endpoint_pod_names
+}`,
+			false,
+			"",
+			true,
+		},
+		// endpoints invalid
+		{
+			`kubernetes coredns.local {
+	endpoint_pod_names giant_seed
+}`,
+			true,
+			"rong argument count or unexpected",
+			false,
+		},
+		// endpoint not set
+		{
+			`kubernetes coredns.local {
+}`,
+			false,
+			"",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		k8sController, err := kubernetesParse(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but did not find error for input '%s'. Error was: '%v'", i, test.input, err)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				continue
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+			}
+			continue
+		}
+
+		// Endpoints
+		foundEndpointNameMode := k8sController.endpointNameMode
+		if foundEndpointNameMode != test.expectedEndpointMode {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with endpoints mode '%v'. Instead found endpoints mode '%v' for input '%s'", i, test.expectedEndpointMode, foundEndpointNameMode, test.input)
+		}
+	}
+}
+
+func TestKubernetesParseNoEndpoints(t *testing.T) {
+	tests := []struct {
+		input                 string // Corefile data as string
+		shouldErr             bool   // true if test case is expected to produce an error.
+		expectedErrContent    string // substring from the expected error. Empty for positive cases.
+		expectedEndpointsInit bool
+	}{
+		// valid
+		{
+			`kubernetes coredns.local {
+	noendpoints
+}`,
+			false,
+			"",
+			false,
+		},
+		// invalid
+		{
+			`kubernetes coredns.local {
+	noendpoints ixnay on the endpointsay
+}`,
+			true,
+			"rong argument count or unexpected",
+			true,
+		},
+		// not set
+		{
+			`kubernetes coredns.local {
+}`,
+			false,
+			"",
+			true,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		k8sController, err := kubernetesParse(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but did not find error for input '%s'. Error was: '%v'", i, test.input, err)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				continue
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+			}
+			continue
+		}
+
+		foundEndpointsInit := k8sController.opts.initEndpointsCache
+		if foundEndpointsInit != test.expectedEndpointsInit {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with endpoints watch '%v'. Instead found endpoints watch '%v' for input '%s'", i, test.expectedEndpointsInit, foundEndpointsInit, test.input)
+		}
+	}
+}
+
+func TestKubernetesParseIgnoreEmptyService(t *testing.T) {
+	tests := []struct {
+		input                 string // Corefile data as string
+		shouldErr             bool   // true if test case is expected to produce an error.
+		expectedErrContent    string // substring from the expected error. Empty for positive cases.
+		expectedEndpointsInit bool
+	}{
+		// valid
+		{
+			`kubernetes coredns.local {
+	ignore empty_service
+}`,
+			false,
+			"",
+			true,
+		},
+		// invalid
+		{
+			`kubernetes coredns.local {
+	ignore ixnay on the endpointsay
+}`,
+			true,
+			"unable to parse ignore value",
+			false,
+		},
+		{
+			`kubernetes coredns.local {
+	ignore empty_service ixnay on the endpointsay
+}`,
+			false,
+			"",
+			true,
+		},
+		// not set
+		{
+			`kubernetes coredns.local {
+}`,
+			false,
+			"",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		k8sController, err := kubernetesParse(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but did not find error for input '%s'. Error was: '%v'", i, test.input, err)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				continue
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+			}
+			continue
+		}
+
+		foundIgnoreEmptyService := k8sController.opts.ignoreEmptyService
+		if foundIgnoreEmptyService != test.expectedEndpointsInit {
+			t.Errorf("Test %d: Expected kubernetes controller to be initialized with ignore empty_service '%v'. Instead found ignore empty_service watch '%v' for input '%s'", i, test.expectedEndpointsInit, foundIgnoreEmptyService, test.input)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/setup_ttl_test.go
+++ b/coredns/plugin/kubernetes/setup_ttl_test.go
@@ -1,0 +1,45 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/caddy"
+)
+
+func TestKubernetesParseTTL(t *testing.T) {
+	tests := []struct {
+		input       string // Corefile data as string
+		expectedTTL uint32 // expected count of defined zones.
+		shouldErr   bool
+	}{
+		{`kubernetes cluster.local {
+			ttl 56
+		}`, 56, false},
+		{`kubernetes cluster.local`, defaultTTL, false},
+		{`kubernetes cluster.local {
+			ttl -1
+		}`, 0, true},
+		{`kubernetes cluster.local {
+			ttl 3601
+		}`, 0, true},
+	}
+
+	for i, tc := range tests {
+		c := caddy.NewTestController("dns", tc.input)
+		k, err := kubernetesParse(c)
+		if err != nil && !tc.shouldErr {
+			t.Fatalf("Test %d: Expected no error, got %q", i, err)
+		}
+		if err == nil && tc.shouldErr {
+			t.Fatalf("Test %d: Expected error, got none", i)
+		}
+		if err != nil && tc.shouldErr {
+			// input should error
+			continue
+		}
+
+		if k.ttl != tc.expectedTTL {
+			t.Errorf("Test %d: Expected TTl to be %d, got %d", i, tc.expectedTTL, k.ttl)
+		}
+	}
+}

--- a/coredns/plugin/kubernetes/watch.go
+++ b/coredns/plugin/kubernetes/watch.go
@@ -1,0 +1,54 @@
+package kubernetes
+
+import (
+	"context"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+func serviceWatchFunc(ctx context.Context, c kubernetes.Interface, ns string, s labels.Selector) func(options meta.ListOptions) (watch.Interface, error) {
+	return func(options meta.ListOptions) (watch.Interface, error) {
+		if s != nil {
+			options.LabelSelector = s.String()
+		}
+		w, err := c.CoreV1().Services(ns).Watch(ctx, options)
+		return w, err
+	}
+}
+
+func podWatchFunc(ctx context.Context, c kubernetes.Interface, ns string, s labels.Selector) func(options meta.ListOptions) (watch.Interface, error) {
+	return func(options meta.ListOptions) (watch.Interface, error) {
+		if s != nil {
+			options.LabelSelector = s.String()
+		}
+		if len(options.FieldSelector) > 0 {
+			options.FieldSelector = options.FieldSelector + ","
+		}
+		options.FieldSelector = options.FieldSelector + "status.phase!=Succeeded,status.phase!=Failed,status.phase!=Unknown"
+		w, err := c.CoreV1().Pods(ns).Watch(ctx, options)
+		return w, err
+	}
+}
+
+func endpointsWatchFunc(ctx context.Context, c kubernetes.Interface, ns string, s labels.Selector) func(options meta.ListOptions) (watch.Interface, error) {
+	return func(options meta.ListOptions) (watch.Interface, error) {
+		if s != nil {
+			options.LabelSelector = s.String()
+		}
+		w, err := c.CoreV1().Endpoints(ns).Watch(ctx, options)
+		return w, err
+	}
+}
+
+func namespaceWatchFunc(ctx context.Context, c kubernetes.Interface, s labels.Selector) func(options meta.ListOptions) (watch.Interface, error) {
+	return func(options meta.ListOptions) (watch.Interface, error) {
+		if s != nil {
+			options.LabelSelector = s.String()
+		}
+		w, err := c.CoreV1().Namespaces().Watch(ctx, options)
+		return w, err
+	}
+}

--- a/coredns/plugin/kubernetes/xfr.go
+++ b/coredns/plugin/kubernetes/xfr.go
@@ -1,0 +1,182 @@
+package kubernetes
+
+import (
+	"context"
+	"math"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/transfer"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+)
+
+// Transfer implements the transfer.Transfer interface.
+func (k *Kubernetes) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	// state is not used here, hence the empty request.Request{]
+	soa, err := plugin.SOA(context.TODO(), k, zone, request.Request{}, plugin.Options{})
+	if err != nil {
+		return nil, transfer.ErrNotAuthoritative
+	}
+
+	ch := make(chan []dns.RR)
+
+	zonePath := msg.Path(zone, "coredns")
+	serviceList := k.APIConn.ServiceList()
+
+	go func() {
+		// ixfr fallback
+		if serial != 0 && soa[0].(*dns.SOA).Serial == serial {
+			ch <- soa
+			close(ch)
+			return
+		}
+		ch <- soa
+
+		sort.Slice(serviceList, func(i, j int) bool {
+			return serviceList[i].Name < serviceList[j].Name
+		})
+
+		for _, svc := range serviceList {
+			if !k.namespaceExposed(svc.Namespace) {
+				continue
+			}
+			svcBase := []string{zonePath, Svc, svc.Namespace, svc.Name}
+			switch svc.Type {
+
+			case api.ServiceTypeClusterIP, api.ServiceTypeNodePort, api.ServiceTypeLoadBalancer:
+				clusterIP := net.ParseIP(svc.ClusterIP)
+				if clusterIP != nil {
+					s := msg.Service{Host: svc.ClusterIP, TTL: k.ttl}
+					s.Key = strings.Join(svcBase, "/")
+
+					// Change host from IP to Name for SRV records
+					host := emitAddressRecord(ch, s)
+
+					for _, p := range svc.Ports {
+						s := msg.Service{Host: host, Port: int(p.Port), TTL: k.ttl}
+						s.Key = strings.Join(svcBase, "/")
+
+						// Need to generate this to handle use cases for peer-finder
+						// ref: https://github.com/coredns/coredns/pull/823
+						ch <- []dns.RR{s.NewSRV(msg.Domain(s.Key), 100)}
+
+						// As per spec unnamed ports do not have a srv record
+						// https://github.com/kubernetes/dns/blob/master/docs/specification.md#232---srv-records
+						if p.Name == "" {
+							continue
+						}
+
+						s.Key = strings.Join(append(svcBase, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
+
+						ch <- []dns.RR{s.NewSRV(msg.Domain(s.Key), 100)}
+					}
+
+					//  Skip endpoint discovery if clusterIP is defined
+					continue
+				}
+
+				endpointsList := k.APIConn.EpIndex(svc.Name + "." + svc.Namespace)
+
+				for _, ep := range endpointsList {
+					if ep.Name != svc.Name || ep.Namespace != svc.Namespace {
+						continue
+					}
+
+					for _, eps := range ep.Subsets {
+						srvWeight := calcSRVWeight(len(eps.Addresses))
+						for _, addr := range eps.Addresses {
+							s := msg.Service{Host: addr.IP, TTL: k.ttl}
+							s.Key = strings.Join(svcBase, "/")
+							// We don't need to change the msg.Service host from IP to Name yet
+							// so disregard the return value here
+							emitAddressRecord(ch, s)
+
+							s.Key = strings.Join(append(svcBase, endpointHostname(addr, k.endpointNameMode)), "/")
+							// Change host from IP to Name for SRV records
+							host := emitAddressRecord(ch, s)
+							s.Host = host
+
+							for _, p := range eps.Ports {
+								// As per spec unnamed ports do not have a srv record
+								// https://github.com/kubernetes/dns/blob/master/docs/specification.md#232---srv-records
+								if p.Name == "" {
+									continue
+								}
+
+								s.Port = int(p.Port)
+
+								s.Key = strings.Join(append(svcBase, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
+								ch <- []dns.RR{s.NewSRV(msg.Domain(s.Key), srvWeight)}
+							}
+						}
+					}
+				}
+
+			case api.ServiceTypeExternalName:
+
+				s := msg.Service{Key: strings.Join(svcBase, "/"), Host: svc.ExternalName, TTL: k.ttl}
+				if t, _ := s.HostType(); t == dns.TypeCNAME {
+					ch <- []dns.RR{s.NewCNAME(msg.Domain(s.Key), s.Host)}
+				}
+			}
+		}
+		ch <- soa
+		close(ch)
+	}()
+	return ch, nil
+}
+
+// emitAddressRecord generates a new A or AAAA record based on the msg.Service and writes it to a channel.
+// emitAddressRecord returns the host name from the generated record.
+func emitAddressRecord(c chan<- []dns.RR, s msg.Service) string {
+	ip := net.ParseIP(s.Host)
+	dnsType, _ := s.HostType()
+	switch dnsType {
+	case dns.TypeA:
+		r := s.NewA(msg.Domain(s.Key), ip)
+		c <- []dns.RR{r}
+		return r.Hdr.Name
+	case dns.TypeAAAA:
+		r := s.NewAAAA(msg.Domain(s.Key), ip)
+		c <- []dns.RR{r}
+		return r.Hdr.Name
+	}
+
+	return ""
+}
+
+// calcSrvWeight borrows the logic implemented in plugin.SRV for dynamically
+// calculating the srv weight and priority
+func calcSRVWeight(numservices int) uint16 {
+	var services []msg.Service
+
+	for i := 0; i < numservices; i++ {
+		services = append(services, msg.Service{})
+	}
+
+	w := make(map[int]int)
+	for _, serv := range services {
+		weight := 100
+		if serv.Weight != 0 {
+			weight = serv.Weight
+		}
+		if _, ok := w[serv.Priority]; !ok {
+			w[serv.Priority] = weight
+			continue
+		}
+		w[serv.Priority] += weight
+	}
+	weight := uint16(math.Floor((100.0 / float64(w[0])) * 100))
+	// weight should be at least 1
+	if weight == 0 {
+		weight = 1
+	}
+
+	return weight
+}

--- a/coredns/plugin/kubernetes/xfr_test.go
+++ b/coredns/plugin/kubernetes/xfr_test.go
@@ -1,0 +1,126 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestKubernetesAXFR(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Namespaces = map[string]struct{}{"testns": {}}
+
+	dnsmsg := &dns.Msg{}
+	dnsmsg.SetAxfr(k.Zones[0])
+
+	ch, err := k.Transfer(k.Zones[0], 0)
+	if err != nil {
+		t.Error(err)
+	}
+	validateAXFR(t, ch)
+}
+
+func TestKubernetesIXFRFallback(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Namespaces = map[string]struct{}{"testns": {}}
+
+	dnsmsg := &dns.Msg{}
+	dnsmsg.SetAxfr(k.Zones[0])
+
+	ch, err := k.Transfer(k.Zones[0], 1)
+	if err != nil {
+		t.Error(err)
+	}
+	validateAXFR(t, ch)
+}
+
+func TestKubernetesIXFRCurrent(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Namespaces = map[string]struct{}{"testns": {}}
+
+	dnsmsg := &dns.Msg{}
+	dnsmsg.SetAxfr(k.Zones[0])
+
+	ch, err := k.Transfer(k.Zones[0], 3)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var gotRRs []dns.RR
+	for rrs := range ch {
+		gotRRs = append(gotRRs, rrs...)
+	}
+
+	// ensure only one record is returned
+	if len(gotRRs) > 1 {
+		t.Errorf("Expected only one answer, got %d", len(gotRRs))
+	}
+
+	// Ensure first record is a SOA
+	if gotRRs[0].Header().Rrtype != dns.TypeSOA {
+		t.Error("Invalid transfer response, does not start with SOA record")
+	}
+}
+
+func validateAXFR(t *testing.T, ch <-chan []dns.RR) {
+	xfr := []dns.RR{}
+	for rrs := range ch {
+		xfr = append(xfr, rrs...)
+	}
+	if xfr[0].Header().Rrtype != dns.TypeSOA {
+		t.Error("Invalid transfer response, does not start with SOA record")
+	}
+
+	zp := dns.NewZoneParser(strings.NewReader(expectedZone), "", "")
+	i := 0
+	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
+		if !dns.IsDuplicate(rr, xfr[i]) {
+			t.Fatalf("Record %d, expected\n%v\n, got\n%v", i, rr, xfr[i])
+		}
+		i++
+	}
+
+	if err := zp.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const expectedZone = `
+cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 3 7200 1800 86400 5
+external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test.
+external-to-service.testns.svc.cluster.local.	5	IN	CNAME	svc1.testns.svc.cluster.local.
+hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2
+172-0-0-2.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2
+_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 172-0-0-2.hdls1.testns.svc.cluster.local.
+hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3
+172-0-0-3.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3
+_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 172-0-0-3.hdls1.testns.svc.cluster.local.
+hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4
+dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4
+_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 dup-name.hdls1.testns.svc.cluster.local.
+hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5
+dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5
+_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 dup-name.hdls1.testns.svc.cluster.local.
+hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1
+5678-abcd--1.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1
+_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 5678-abcd--1.hdls1.testns.svc.cluster.local.
+hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2
+5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2
+_http._tcp.hdls1.testns.svc.cluster.local.	5	IN	SRV	0 16 80 5678-abcd--2.hdls1.testns.svc.cluster.local.
+hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20
+172-0-0-20.hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20
+svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1
+svc1.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.
+_http._tcp.svc1.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.
+svc6.testns.svc.cluster.local.	5	IN	AAAA	1234:abcd::1
+svc6.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc6.testns.svc.cluster.local.
+_http._tcp.svc6.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc6.testns.svc.cluster.local.
+svcempty.testns.svc.cluster.local.	5	IN	A	10.0.0.1
+svcempty.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.
+_http._tcp.svcempty.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.
+cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 3 7200 1800 86400 5
+`

--- a/pkg/agent/edgedns.go
+++ b/pkg/agent/edgedns.go
@@ -47,7 +47,7 @@ const (
     forward . /etc/resolv.conf {
       prefer_udp
     }
-	{{ if .Probe -}}
+    {{ if .Probe -}}
     health {
         lameduck 5s
     }


### PR DESCRIPTION
kubeedge metaServer has a bug(https://github.com/kubeedge/kubeedge/issues/4582) which cause coredns missing namespace events, change namespaceExposed function can temporarily fix this problem.