### PR TITLE
Improve strongswan connection initialization

### DIFF
--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -96,6 +96,15 @@ func (m *Manager) start() {
 		lastCancel()
 	}()
 
+	m.log.V(3).Info("Waiting for strongswan to start")
+	for {
+		if m.tm.IsRunning() {
+			break
+		}
+
+		time.Sleep(time.Second)
+	}
+
 	m.log.V(3).Info("start network synchronization")
 	go m.sync()
 

--- a/pkg/tunnel/manager.go
+++ b/pkg/tunnel/manager.go
@@ -19,6 +19,7 @@ import (
 )
 
 type Manager interface {
+	IsRunning() bool
 	ListConnNames() ([]string, error)
 	LoadConn(conn ConnConfig) error
 	InitiateConn(name string) error


### PR DESCRIPTION
Sometimes strongswan will created connection which is stucked queued state when it's mediator is not online, it's helpful to check mediator's state before initiate normal connection.