### PR TITLE
Use iptables-wrapper and change base image

### DIFF
--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -8,12 +8,16 @@ RUN cd /tmp && git clone https://gitee.com/fabedge/plugins.git && \
     chmod a+x /fabedge/pkg/agent/env_prepare.sh && \
     cp /fabedge/pkg/agent/env_prepare.sh /tmp
 
-FROM alpine:3.15
-COPY --from=builder /fabedge/_output/fabedge-agent /tmp/bridge /tmp/host-local /tmp/loopback /tmp/portmap /tmp/bandwidth /tmp/env_prepare.sh /usr/local/bin/
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && \
-    apk add iptables && \
-    apk add ip6tables && \
-    apk add ipvsadm && \
-    apk add ipset && \
-    rm -rf /var/cache/apk/*
-ENTRYPOINT ["/usr/local/bin/fabedge-agent"]
+FROM fabedge/base-image:0.1.0
+
+COPY --from=builder /fabedge/build/agent/entrypoint.sh /
+COPY --from=builder /fabedge/_output/fabedge-agent \
+    /tmp/bridge \
+    /tmp/host-local \
+    /tmp/loopback \
+    /tmp/portmap \
+    /tmp/bandwidth \
+    /tmp/env_prepare.sh \
+    /usr/local/bin/
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/build/agent/entrypoint.sh
+++ b/build/agent/entrypoint.sh
@@ -4,6 +4,6 @@ set -e
 echo 'select between the two modes of iptables ("legacy" and "nft")'
 /iptables-wrapper-installer.sh
 
-cmd="/usr/local/bin/fabedge-cloud-agent $@"
+cmd="/usr/local/bin/fabedge-agent $@"
 echo "entrypoint:    run command: $cmd"
 exec $cmd

--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.17.13 as builder
+RUN mkdir /iptables-wrapper && \
+    cd /iptables-wrapper && \
+    git clone https://github.com/kubernetes-sigs/iptables-wrappers.git . && \
+    make build
+
+FROM alpine:3.15
+COPY --from=builder /iptables-wrapper/iptables-wrapper-installer.sh \
+    /iptables-wrapper/bin/iptables-wrapper /
+
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && \
+    apk --update add iptables && \
+    apk --update add ip6tables && \
+    apk --update add ipset && \
+    apk --update add ipvsadm && \
+    rm -rf /var/cache/apk/*

--- a/build/base-image/README.md
+++ b/build/base-image/README.md
@@ -1,0 +1,5 @@
+# Base Image
+
+This Dockerfile is used to make base-image which is mainly used by agent, connector, cloud-agent.  Base image contains iptables/ip6tables, ipvsadm, ipset and iptables-wrapper, these are all needed by componets metioned before. 
+
+[iptables-wrapper](https://github.com/kubernetes-sigs/iptables-wrappers) is the main reason for base-image, it can detect iptables version on host machine during runtime and change links to corresponding implementation in container, this is important, without it, those components might not create iptables rules correctly.

--- a/build/cloud-agent/Dockerfile
+++ b/build/cloud-agent/Dockerfile
@@ -2,16 +2,11 @@ FROM golang:1.17.13 as builder
 COPY . /fabedge
 RUN cd /fabedge && make cloud-agent QUICK=1 CGO_ENABLED=0 GOPROXY=https://goproxy.cn,direct
 
-FROM alpine:3.15
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && \
-    apk add iptables && \
-    apk add ip6tables && \
-    apk add ipset && \
-    rm -rf /var/cache/apk/*
+FROM fabedge/base-image:0.1.0
 
 COPY --from=builder /fabedge/_output/fabedge-cloud-agent /usr/local/bin/
-
 COPY --from=builder /fabedge/build/cloud-agent/entrypoint.sh /
+
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/connector/Dockerfile
+++ b/build/connector/Dockerfile
@@ -2,15 +2,11 @@ FROM golang:1.17.13 as builder
 COPY . /fabedge
 RUN cd /fabedge && make connector QUICK=1 CGO_ENABLED=0 GOPROXY=https://goproxy.cn,direct
 
-FROM alpine:3.15
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && \
-    apk --update add iptables && \
-    apk --update add ip6tables && \
-    apk --update add ipset && \
-    rm -rf /var/cache/apk/*
+FROM fabedge/base-image:0.1.0
 
 COPY --from=builder /fabedge/_output/fabedge-connector /usr/local/bin/connector
 COPY --from=builder /fabedge/build/connector/entrypoint.sh /
+
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/connector/entrypoint.sh
+++ b/build/connector/entrypoint.sh
@@ -1,18 +1,8 @@
 #!/bin/sh
-
 set -e
 
-function is_nft_loaded
-{
-  lsmod | grep table | grep nft >/dev/null
-}
-
-if is_nft_loaded; then
-   echo "entrypoint:    use iptables of nft mode"
-   ln -sf /sbin/xtables-nft-multi /sbin/iptables
-else
-   echo "entrypoint:    use iptables of legacy mode"
-fi
+echo 'select between the two modes of iptables ("legacy" and "nft")'
+/iptables-wrapper-installer.sh
 
 cmd="/usr/local/bin/connector $@"
 echo "entrypoint:    run command: $cmd"


### PR DESCRIPTION
For a long time, images of agent, connector and cloud-agent uses iptables-legacy to configure rules, but some OS uses iptables-nft which might cause these component to misfunction, use iptables-wrapper can fix this problem.