### PR TITLE
Update manually-install documents.

### DIFF
--- a/docs/manually-install.md
+++ b/docs/manually-install.md
@@ -101,8 +101,10 @@ cluster:
   # edgePodCIDR is not necessary if your CNI is flannel;
   # Avoid an CIDR overlapped with cluster-cidr argument of your cluster
   edgePodCIDR: "10.234.64.0/18" 
+  # It's the value of "cluster-cidr" fetched in Step 2
+  clusterCIDR: "10.233.64.0/18"
   # Usually connector should be accessible by fabedge-agent by port 500,
-  # if you cann't map public port 500, change this parameter.
+  # if you can't map public port 500, change this parameter.
   connectorPublicPort: 500
   # If your edge nodes are behind NAT networks and are hard to establish
   # tunnels between them, set this parameter to true, this will let connector
@@ -110,6 +112,7 @@ cluster:
   connectorAsMediator: false
   connectorPublicAddresses:
   - 10.22.48.16
+  # It's the value of "service-cluster-ip-range" fetched in Step 2
   serviceClusterIPRange:
   - 10.234.0.0/18
 
@@ -125,12 +128,12 @@ agent:
     ENABLE_DNS: "true"
 ```
 
-*PS:  The `values.yaml` in the example is not complete, you can get the complete `values.yaml` example by executing `helm show values fabedge-0.6.0.tgz`.*
+*PS:  The `values.yaml` in the example is not complete, you can get the complete `values.yaml` example by executing `helm show values fabedge/fabedge`.*
 
 8. Deploy Fabedge
 
    ```shell
-   helm install fabedge fabedge-0.6.0.tgz -n fabedge --create-namespace
+   helm install fabedge fabedge/fabedge -n fabedge --create-namespace -f values.yaml
    ```
 
 If those pods following are running, you make it.

--- a/docs/manually-install_zh.md
+++ b/docs/manually-install_zh.md
@@ -100,6 +100,8 @@ cluster:
   # 如果是flannel，可以不配置这个参数;
   # 另外这个参数需要注意不要跟当前集群的cluster-cidr参数重叠
   edgePodCIDR: "10.234.64.0/18" 
+  # 填入步骤2中的cluster-cidr
+  clusterCIDR: "10.233.64.0/18"
   connectorPublicAddresses:
   - 10.22.48.16
   # 通常connector需要被边缘节点的fabedge-agent访问需要映射端口，
@@ -108,6 +110,7 @@ cluster:
   # 是否使用connector节点作为mediator，如果边缘节点位于NAT网络后，
   # 彼此之间不能正常建立隧道，建议开启该功能
   connectorAsMediator: false
+  # 填入步骤2中的service-cluster-ip-range
   serviceClusterIPRange:
   - 10.234.0.0/18
 
@@ -127,7 +130,7 @@ agent:
 8. 安装Fabedge
 
    ```shell
-   helm install fabedge fabedge/fabedge -n fabedge --create-namespace
+   helm install fabedge fabedge/fabedge -n fabedge --create-namespace -f values.yaml
    ```
 
 如果以下Pod运行正常，则安装成功


### PR DESCRIPTION
Avoid the "CrashLoopBackOff" error of the fabedge-connector if the "clusterCIDR" is not configured.
Related log is like:
`cmd.go:53] agent "msg"="invalid arguments found" "error"="cluster-cidr is needed"`