### PR TITLE
Let agent, cloud-agent, connector use the same ipset names

### DIFF
--- a/pkg/agent/iptables.go
+++ b/pkg/agent/iptables.go
@@ -73,8 +73,8 @@ func (m *Manager) ensureIPTablesRules() error {
 	subnetsIP4, subnetsIP6 := classifySubnets(current.Subnets)
 
 	if !areSubnetsEqual(current.Subnets, m.lastSubnets) {
-		m.ipt = iptables.NewApplierCleaner(iptables.ProtocolIPv4, jumpChains, buildRuleData(IPSetFabEdgePeerCIDR, subnetsIP4))
-		m.ipt6 = iptables.NewApplierCleaner(iptables.ProtocolIPv6, jumpChains, buildRuleData(IPSetFabEdgePeerCIDR6, subnetsIP6))
+		m.ipt = iptables.NewApplierCleaner(iptables.ProtocolIPv4, jumpChains, buildRuleData(ipset.RemoteCIDR, subnetsIP4))
+		m.ipt6 = iptables.NewApplierCleaner(iptables.ProtocolIPv6, jumpChains, buildRuleData(ipset.RemoteCIDR6, subnetsIP6))
 		m.lastSubnets = current.Subnets
 	}
 
@@ -84,8 +84,8 @@ func (m *Manager) ensureIPTablesRules() error {
 		peerIPSet  sets.String
 		ipt        iptables.ApplierCleaner
 	}{
-		{IPSetFabEdgePeerCIDR, ipset.ProtocolFamilyIPV4, peerIPSet4, m.ipt},
-		{IPSetFabEdgePeerCIDR6, ipset.ProtocolFamilyIPV6, peerIPSet6, m.ipt6},
+		{ipset.RemoteCIDR, ipset.ProtocolFamilyIPV4, peerIPSet4, m.ipt},
+		{ipset.RemoteCIDR6, ipset.ProtocolFamilyIPV6, peerIPSet6, m.ipt6},
 	}
 
 	var errors []error

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -36,11 +36,6 @@ import (
 	"github.com/fabedge/fabedge/third_party/ipvs"
 )
 
-const (
-	IPSetFabEdgePeerCIDR  = "FABEDGE-PEER-CIDR"
-	IPSetFabEdgePeerCIDR6 = "FABEDGE-PEER-CIDR6"
-)
-
 type Manager struct {
 	Config
 

--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -36,42 +36,44 @@ const (
 	ProtocolFamilyIPV6 = ipset.ProtocolFamilyIPV6
 )
 
+// Remote refers to nodes or pods in different LANs, maybe even not in the same cluster,
+// while Local refers to nodes or pods in the same LAN and the same cluster.
 const (
-	IPSetEdgePodCIDR    = "FABEDGE-EDGE-POD-CIDR"
-	IPSetEdgePodCIDR6   = "FABEDGE-EDGE-POD-CIDR6"
-	IPSetEdgeNodeCIDR   = "FABEDGE-EDGE-NODE-CIDR"
-	IPSetEdgeNodeCIDR6  = "FABEDGE-EDGE-NODE-CIDR6"
-	IPSetCloudPodCIDR   = "FABEDGE-CLOUD-POD-CIDR"
-	IPSetCloudPodCIDR6  = "FABEDGE-CLOUD-POD-CIDR6"
-	IPSetCloudNodeCIDR  = "FABEDGE-CLOUD-NODE-CIDR"
-	IPSetCloudNodeCIDR6 = "FABEDGE-CLOUD-NODE-CIDR6"
-	IPSetRemotePodCIDR  = "FABEDGE-REMOTE-POD-CIDR"
-	IPSetRemotePodCIDR6 = "FABEDGE-REMOTE-POD-CIDR6"
+	RemotePodCIDR   = "FABEDGE-REMOTE-POD-CIDR"
+	RemotePodCIDR6  = "FABEDGE-REMOTE-POD-CIDR6"
+	RemoteNodeCIDR  = "FABEDGE-REMOTE-NODE-CIDR"
+	RemoteNodeCIDR6 = "FABEDGE-REMOTE-NODE-CIDR6"
+	LocalPodCIDR    = "FABEDGE-LOCAL-POD-CIDR"
+	LocalPodCIDR6   = "FABEDGE-LOCAL-POD-CIDR6"
+	LocalNodeCIDR   = "FABEDGE-LOCAL-NODE-CIDR"
+	LocalNodeCIDR6  = "FABEDGE-LOCAL-NODE-CIDR6"
+	RemoteCIDR      = "FABEDGE-REMOTE-CIDR"
+	RemoteCIDR6     = "FABEDGE-REMOTE-CIDR6"
 )
 
 type IPSetNames struct {
-	EdgePodCIDR   string
-	EdgeNodeCIDR  string
-	CloudPodCIDR  string
-	CloudNodeCIDR string
-	RemotePodCIDR string
+	RemotePodCIDR  string
+	RemoteNodeCIDR string
+	LocalPodCIDR   string
+	LocalNodeCIDR  string
+	RemoteCIDR     string
 }
 
 var (
 	Names4 = IPSetNames{
-		EdgeNodeCIDR:  IPSetEdgeNodeCIDR,
-		EdgePodCIDR:   IPSetEdgePodCIDR,
-		CloudPodCIDR:  IPSetCloudPodCIDR,
-		CloudNodeCIDR: IPSetCloudNodeCIDR,
-		RemotePodCIDR: IPSetRemotePodCIDR,
+		RemoteNodeCIDR: RemoteNodeCIDR,
+		RemotePodCIDR:  RemotePodCIDR,
+		LocalPodCIDR:   LocalPodCIDR,
+		LocalNodeCIDR:  LocalNodeCIDR,
+		RemoteCIDR:     RemoteCIDR,
 	}
 
 	Names6 = IPSetNames{
-		EdgeNodeCIDR:  IPSetEdgeNodeCIDR6,
-		EdgePodCIDR:   IPSetEdgePodCIDR6,
-		CloudPodCIDR:  IPSetCloudPodCIDR6,
-		CloudNodeCIDR: IPSetCloudNodeCIDR6,
-		RemotePodCIDR: IPSetRemotePodCIDR6,
+		RemoteNodeCIDR: RemoteNodeCIDR6,
+		RemotePodCIDR:  RemotePodCIDR6,
+		LocalPodCIDR:   LocalPodCIDR6,
+		LocalNodeCIDR:  LocalNodeCIDR6,
+		RemoteCIDR:     RemoteCIDR6,
 	}
 )
 


### PR DESCRIPTION
It's better to use Remote and Local rather than Cloud and Edge to orangize ipsets because in multi-clusters enviroment, connector will put CIDR of other clusters in edge ipset, this is confusing.