### PR TITLE
Use submodule to avoid redundant pulling of repo when building agent.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build/agent/plugins"]
+	path = build/agent/plugins
+	url = https://github.com/containernetworking/plugins

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.17.13 as builder
 ARG pluginVersion=v0.9.1
 COPY . /fabedge
-RUN cd /tmp && git clone https://gitee.com/fabedge/plugins.git && \
-    cd /tmp/plugins && git checkout ${pluginVersion} && bash build_linux.sh -ldflags "-extldflags -static -X 'github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${pluginVersion}'" && \
-    cd /tmp/plugins/bin && cp bridge host-local loopback portmap bandwidth /tmp/ && \
+RUN cd /fabedge/build/agent/plugins && git checkout ${pluginVersion} && bash build_linux.sh -ldflags "-extldflags -static -X 'github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${pluginVersion}'" && \
+    cd /fabedge/build/agent/plugins/bin && cp bridge host-local loopback portmap bandwidth /tmp/ && \
     cd /fabedge && make agent QUICK=1 CGO_ENABLED=0 GOPROXY=https://goproxy.cn,direct && \
     chmod a+x /fabedge/pkg/agent/env_prepare.sh && \
     cp /fabedge/pkg/agent/env_prepare.sh /tmp


### PR DESCRIPTION
Developers may need to execute `git submodule update --init --recursive` after cloning.